### PR TITLE
fix: config type bridge + nil-guard apply result (#8)

### DIFF
--- a/internal/root/apply.go
+++ b/internal/root/apply.go
@@ -71,8 +71,10 @@ func runApply(action mgrAction) func(*cobra.Command, []string) error {
 				return fmt.Errorf("refusing to apply without --yes")
 			}
 			r, err := orch.Apply(ctx)
-			fmt.Printf("apply: applied=%d skipped=%d failed=%d\n",
-				len(r.Applied), len(r.Skipped), len(r.Failed))
+			if r != nil {
+				fmt.Printf("apply: applied=%d skipped=%d failed=%d\n",
+					len(r.Applied), len(r.Skipped), len(r.Failed))
+			}
 			return err
 		case actionVerify:
 			v, err := orch.Verify(ctx)

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -259,16 +259,16 @@ func TestManager_PlanVerify_DiskMount(t *testing.T) {
 	}
 }
 
-// TestManager_Package_User_UnsupportedTypeBug documents the pre-existing bug:
-// runManager wires the raw *config.UsersGroups / *config.Packages into the
-// manager's Spec, which doesn't match its cast helpers. Until a prod fix, we
-// assert the error surface so the path is covered.
-func TestManager_Package_User_UnsupportedTypeBug(t *testing.T) {
+// TestManager_Package_User_TypeConversionFix verifies the fix for linuxctl#8:
+// runManager now converts *config.UsersGroups → managers.UsersGroupsSpec and
+// *config.Packages → managers.PackagesSpec via bridge helpers in runtime.go,
+// so the cast helpers no longer return "unsupported desired-state type".
+func TestManager_Package_User_TypeConversionFix(t *testing.T) {
 	linux := writeMinimalLinux(t)
 	for _, name := range []string{"user", "package"} {
 		_, err := executeCmd(t, name, "plan", linux)
-		if err == nil || !strings.Contains(err.Error(), "unsupported desired-state type") {
-			t.Errorf("%s plan: expected type-mismatch bug, got %v", name, err)
+		if err != nil && strings.Contains(err.Error(), "unsupported desired-state type") {
+			t.Errorf("%s plan: type-mismatch bug reappeared: %v", name, err)
 		}
 	}
 }

--- a/internal/root/runtime.go
+++ b/internal/root/runtime.go
@@ -120,11 +120,50 @@ func desiredFor(linux *config.Linux, name string) managers.Spec {
 	case "mount":
 		return linux.Mounts
 	case "user":
-		return linux.UsersGroups
+		return usersGroupsSpec(linux.UsersGroups)
 	case "dir":
 		return linux.Directories
 	case "package":
-		return linux.Packages
+		return packagesSpec(linux.Packages)
 	}
 	return linux
+}
+
+// usersGroupsSpec converts the typed config.UsersGroups (nominal type) into
+// the shape the managers package expects. Both structs are structurally
+// identical but distinct nominal types; managers.castUsersGroups previously
+// rejected config.*UsersGroups with "unsupported desired-state type".
+// Fixes linuxctl#8.
+func usersGroupsSpec(ug *config.UsersGroups) managers.UsersGroupsSpec {
+	if ug == nil {
+		return managers.UsersGroupsSpec{}
+	}
+	spec := managers.UsersGroupsSpec{}
+	for _, g := range ug.Groups {
+		spec.Groups = append(spec.Groups, managers.GroupSpec{Name: g.Name, GID: g.GID})
+	}
+	for _, u := range ug.Users {
+		spec.Users = append(spec.Users, managers.UserSpec{
+			Name:     u.Name,
+			UID:      u.UID,
+			GID:      u.GID,
+			Groups:   u.Groups,
+			Home:     u.Home,
+			Shell:    u.Shell,
+			SSHKeys:  u.SSHKeys,
+			Password: u.Password,
+		})
+	}
+	return spec
+}
+
+// packagesSpec converts config.Packages → managers.PackagesSpec. Fixes linuxctl#8.
+func packagesSpec(p *config.Packages) managers.PackagesSpec {
+	if p == nil {
+		return managers.PackagesSpec{}
+	}
+	return managers.PackagesSpec{
+		Install: p.Install,
+		Remove:  p.Remove,
+	}
 }


### PR DESCRIPTION
Fixes linuxctl#8 runManager type mismatch + apply.go nil deref. Closes #8.