### PR TITLE
feat: conventions library (plan 033) — 19 shipped presets + CLI + bundle expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,44 @@ All notable changes to `linuxctl` are documented in this file. The format follow
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 CalVer (`vYYYY.MM.DD.TS`).
 
+## v2026.04.11.9 — 2026-04-22
+
+### Added — Conventions library (plan 033, #19)
+
+- `pkg/presets/` — embedded preset engine with 19 shipped presets (`go:embed`
+  YAML under `pkg/presets/data/`). Categories: directories (3),
+  users_groups (3), packages (4), sysctl (2), limits (2), bundles (5).
+- 4 new Linux config fields: `directories_preset`, `users_groups_preset`,
+  `packages_preset`, `bundle_preset`. All optional and additive — existing
+  manifests continue to work unchanged.
+- `linuxctl preset list [--category] [--tier]` — tabular discovery
+- `linuxctl preset show <name> [--expand]` — inspect a preset or bundle
+- `linuxctl config render` now implemented (was stub). Expands
+  `bundle_preset` + per-category `*_preset` fields into the final desired
+  state, redacts `${vault:...}` / `${gen:...}` placeholders.
+- Tier gating: all Phase-1 presets are community tier.
+  `hardened-cis-l1` / `hardened-cis-l2` reserved for business tier.
+
+### Changed
+
+- `pkg/managers/sysctl.go` + `pkg/managers/limits.go`: hardcoded
+  `oracle-19c` preset data migrated to YAML under
+  `pkg/presets/data/{sysctl,limits}/oracle-19c.yaml`. Behaviour preserved
+  byte-for-byte; existing tests (`TestSysctl_PresetExpansion`,
+  `TestSysctl_MergePresetExplicit`, `TestLimits_PresetExpansion`,
+  `TestSysctl_Plan_PresetMerge`) remain green as regression gate.
+- `pkg/managers/dir.go`, `user.go`, `package.go` accept `*config.Linux`
+  and transparently merge the referenced preset (explicit entries win).
+- `pkg/config.Linux` loader calls `expandBundleOnLinux` after YAML decode
+  so `bundle_preset` populates per-category `*_preset` fields (only when
+  the user has not set them explicitly).
+
+### Migration
+
+- Stacks using `bundle_preset: oracle-rac-19c` drop ~60 lines of
+  boilerplate (see `infrastructure/stacks/clext5/os/linux.yaml` —
+  migration lands in the infra repo alongside the linuxctl release).
+
 ## v2026.04.11.8 — 2026-04-22
 
 ### BREAKING — CLI verb rename `env` → `stack` (#17)

--- a/internal/root/config.go
+++ b/internal/root/config.go
@@ -2,10 +2,14 @@ package root
 
 import (
 	"fmt"
+	"regexp"
+	"strings"
 
 	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
 
 	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 )
 
 func newConfigCmd() *cobra.Command {
@@ -31,10 +35,10 @@ func newConfigCmd() *cobra.Command {
 	})
 	cmd.AddCommand(&cobra.Command{
 		Use:   "render <path>",
-		Short: "Render with resolved secrets (redacted)",
+		Short: "Render with bundles + presets expanded and secrets redacted",
 		Args:  cobra.ExactArgs(1),
-		RunE: func(_ *cobra.Command, _ []string) error {
-			return fmt.Errorf("config render: not implemented")
+		RunE: func(c *cobra.Command, args []string) error {
+			return runConfigRender(c, args[0])
 		},
 	})
 	cmd.AddCommand(&cobra.Command{
@@ -53,4 +57,72 @@ func newConfigCmd() *cobra.Command {
 		},
 	})
 	return cmd
+}
+
+// secretRef matches ${vault:...} and ${gen:...} placeholders for redaction.
+var secretRef = regexp.MustCompile(`\$\{(vault|gen):[^}]+\}`)
+
+// runConfigRender loads a linux.yaml, expands bundle_preset + per-category
+// *_preset fields into the final desired state, redacts secret references,
+// and prints the resulting YAML to stdout.
+func runConfigRender(c *cobra.Command, path string) error {
+	l, err := config.LoadLinux(path)
+	if err != nil {
+		return err
+	}
+	// Resolve each *_preset and merge into the explicit entries.
+	if l.DirectoriesPreset != "" {
+		if p, err := presets.ResolveCategory("directories", l.DirectoriesPreset, nil); err == nil {
+			if dirs, err := presets.DirectoriesSpec(p); err == nil {
+				l.Directories = presets.MergeDirectories(l.Directories, dirs)
+			}
+		}
+	}
+	if l.UsersGroupsPreset != "" {
+		if p, err := presets.ResolveCategory("users_groups", l.UsersGroupsPreset, nil); err == nil {
+			if ug, err := presets.UsersGroupsSpec(p); err == nil && ug != nil {
+				explicit := config.UsersGroups{}
+				if l.UsersGroups != nil {
+					explicit = *l.UsersGroups
+				}
+				merged := presets.MergeUsersGroups(explicit, *ug)
+				l.UsersGroups = &merged
+			}
+		}
+	}
+	if l.PackagesPreset != "" {
+		if p, err := presets.ResolveCategory("packages", l.PackagesPreset, nil); err == nil {
+			if pp, err := presets.PackagesSpec(p); err == nil && pp != nil {
+				explicit := config.Packages{}
+				if l.Packages != nil {
+					explicit = *l.Packages
+				}
+				merged := presets.MergePackages(explicit, *pp)
+				l.Packages = &merged
+			}
+		}
+	}
+	if l.SysctlPreset != "" {
+		if p, err := presets.ResolveCategory("sysctl", l.SysctlPreset, nil); err == nil {
+			if entries, err := presets.SysctlSpec(p); err == nil {
+				l.Sysctl = presets.MergeSysctl(l.Sysctl, entries)
+			}
+		}
+	}
+	if l.LimitsPreset != "" {
+		if p, err := presets.ResolveCategory("limits", l.LimitsPreset, nil); err == nil {
+			if entries, err := presets.LimitsSpec(p); err == nil {
+				l.Limits = presets.MergeLimits(l.Limits, entries)
+			}
+		}
+	}
+
+	b, err := yaml.Marshal(l)
+	if err != nil {
+		return err
+	}
+	redacted := secretRef.ReplaceAllString(string(b), "<REDACTED>")
+	out := c.OutOrStdout()
+	_, err = fmt.Fprint(out, strings.TrimRight(redacted, "\n")+"\n")
+	return err
 }

--- a/internal/root/preset.go
+++ b/internal/root/preset.go
@@ -1,0 +1,134 @@
+package root
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/itunified-io/linuxctl/pkg/presets"
+)
+
+// newPresetCmd builds the `linuxctl preset` subtree: discovery + inspection
+// of the embedded conventions library (plan 033).
+func newPresetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "preset",
+		Short: "Discover and inspect the linuxctl conventions library",
+		Long: `The conventions library ships as YAML presets embedded in the linuxctl
+binary. Use "linuxctl preset list" to browse what is available and
+"linuxctl preset show <name>" to print a preset's content.
+
+Bundles compose one preset per category; "linuxctl preset show <bundle> --expand"
+prints all referenced presets.`,
+	}
+	cmd.AddCommand(newPresetListCmd())
+	cmd.AddCommand(newPresetShowCmd())
+	return cmd
+}
+
+func newPresetListCmd() *cobra.Command {
+	var category string
+	var tierStr string
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List presets available to the active tier",
+		RunE: func(_ *cobra.Command, _ []string) error {
+			tier := presets.TierCommunity
+			if tierStr != "" {
+				tier = presets.Tier(tierStr)
+			}
+			metas := presets.List(func() presets.Tier { return tier })
+			if category != "" {
+				filtered := metas[:0]
+				for _, m := range metas {
+					if m.Category == category {
+						filtered = append(filtered, m)
+					}
+				}
+				metas = filtered
+			}
+			sort.Slice(metas, func(i, j int) bool {
+				if metas[i].Category != metas[j].Category {
+					return metas[i].Category < metas[j].Category
+				}
+				return metas[i].Name < metas[j].Name
+			})
+			tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+			fmt.Fprintln(tw, "CATEGORY\tNAME\tTIER\tVERSION\tSOURCE")
+			for _, m := range metas {
+				src := m.Source
+				if len(src) > 60 {
+					src = src[:57] + "..."
+				}
+				fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", m.Category, m.Name, m.Tier, m.Version, src)
+			}
+			return tw.Flush()
+		},
+	}
+	cmd.Flags().StringVar(&category, "category", "", "filter by category (directories|users_groups|packages|sysctl|limits|bundles)")
+	cmd.Flags().StringVar(&tierStr, "tier", "", "override active tier (community|business|enterprise)")
+	return cmd
+}
+
+func newPresetShowCmd() *cobra.Command {
+	var expand bool
+	cmd := &cobra.Command{
+		Use:   "show <name>",
+		Short: "Print a preset's YAML; --expand for bundles",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(_ *cobra.Command, args []string) error {
+			name := args[0]
+			// Try every category; preset names can repeat across categories.
+			candidates := []string{"bundles", "directories", "users_groups", "packages", "sysctl", "limits"}
+			var found []*presets.Preset
+			for _, c := range candidates {
+				if p, err := presets.ResolveCategory(c, name, nil); err == nil {
+					found = append(found, p)
+				}
+			}
+			if len(found) == 0 {
+				return fmt.Errorf("preset %q not found in any category", name)
+			}
+			for _, p := range found {
+				b, err := yaml.Marshal(p)
+				if err != nil {
+					return err
+				}
+				fmt.Printf("# %s/%s\n", p.Metadata.Category, p.Metadata.Name)
+				fmt.Println(strings.TrimSpace(string(b)))
+				fmt.Println("---")
+				if expand && p.Kind == "Bundle" {
+					children, err := presets.BundleExpand(p.Metadata.Name, nil)
+					if err != nil {
+						return err
+					}
+					cats := make([]string, 0, len(children))
+					for c := range children {
+						cats = append(cats, c)
+					}
+					sort.Strings(cats)
+					for _, c := range cats {
+						childName := children[c]
+						cp, err := presets.ResolveCategory(c, childName, nil)
+						if err != nil {
+							fmt.Fprintf(os.Stderr, "warning: cannot resolve %s/%s: %v\n", c, childName, err)
+							continue
+						}
+						cb, _ := yaml.Marshal(cp)
+						fmt.Printf("# %s/%s (via bundle %s)\n", c, childName, p.Metadata.Name)
+						fmt.Println(strings.TrimSpace(string(cb)))
+						fmt.Println("---")
+					}
+				}
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&expand, "expand", false, "for bundles, also print each referenced preset")
+	return cmd
+}

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -120,6 +120,9 @@ func NewRootCmd(info BuildInfo) *cobra.Command {
 	cmd.AddCommand(newApplyCmd())
 	cmd.AddCommand(newDiffCmd())
 
+	// Conventions library (plan 033).
+	cmd.AddCommand(newPresetCmd())
+
 	// Meta.
 	cmd.AddCommand(newLicenseCmd())
 	cmd.AddCommand(newVersionCmd(info))

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -157,10 +157,31 @@ func TestConfig_Validate_BadYAML(t *testing.T) {
 	}
 }
 
-func TestConfig_Render_NotImplemented(t *testing.T) {
-	_, err := executeCmd(t, "config", "render", "/tmp/x.yaml")
-	if err == nil || !strings.Contains(err.Error(), "not implemented") {
-		t.Errorf("render err = %v", err)
+func TestConfig_Render_ImplementedErrorsOnMissingFile(t *testing.T) {
+	// Plan 033: config render is now implemented. A missing file path must
+	// surface a read error, not "not implemented".
+	_, err := executeCmd(t, "config", "render", "/tmp/does-not-exist-xx-linuxctl.yaml")
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if strings.Contains(err.Error(), "not implemented") {
+		t.Errorf("render should be implemented; err = %v", err)
+	}
+}
+
+func TestConfig_Render_ExpandsBundlePreset(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	content := []byte("kind: Linux\nbundle_preset: minimal-host\n")
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := executeCmd(t, "config", "render", p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out, "cifs-utils") {
+		t.Errorf("render output should expand bundle to include cifs-utils; got:\n%s", out)
 	}
 }
 

--- a/pkg/config/bundle_expand_test.go
+++ b/pkg/config/bundle_expand_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestLoadLinux_BundleExpansion verifies that when pkg/presets is imported
+// (which registers the bundle expander), LoadLinux expands bundle_preset
+// into per-category *_preset fields, with explicit per-category presets
+// always winning.
+func TestLoadLinux_BundleExpansion(t *testing.T) {
+	// Register a stub expander so this test does not depend on pkg/presets.
+	old := bundleExpander
+	t.Cleanup(func() { bundleExpander = old })
+	RegisterBundleExpander(func(name string) (map[string]string, error) {
+		if name == "test-bundle" {
+			return map[string]string{
+				"directories":  "bundle-dirs",
+				"users_groups": "bundle-users",
+				"packages":     "bundle-pkgs",
+				"sysctl":       "bundle-sysctl",
+				"limits":       "bundle-limits",
+			}, nil
+		}
+		return nil, nil
+	})
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	content := []byte(`kind: Linux
+bundle_preset: test-bundle
+sysctl_preset: explicit-sysctl
+`)
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l, err := LoadLinux(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.DirectoriesPreset != "bundle-dirs" {
+		t.Errorf("DirectoriesPreset: want bundle-dirs, got %q", l.DirectoriesPreset)
+	}
+	if l.SysctlPreset != "explicit-sysctl" {
+		t.Errorf("explicit SysctlPreset should win over bundle, got %q", l.SysctlPreset)
+	}
+	if l.LimitsPreset != "bundle-limits" {
+		t.Errorf("LimitsPreset: want bundle-limits, got %q", l.LimitsPreset)
+	}
+}
+
+func TestLoadLinux_BundleExpansion_NoHook(t *testing.T) {
+	old := bundleExpander
+	t.Cleanup(func() { bundleExpander = old })
+	bundleExpander = nil
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	if err := os.WriteFile(p, []byte("kind: Linux\nbundle_preset: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l, err := LoadLinux(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if l.BundlePreset != "x" {
+		t.Errorf("bundle preset should remain unexpanded without hook, got %q", l.BundlePreset)
+	}
+}

--- a/pkg/config/linux.go
+++ b/pkg/config/linux.go
@@ -15,6 +15,13 @@ type Linux struct {
 	SysctlPreset string         `yaml:"sysctl_preset,omitempty"`
 	Limits       []LimitEntry   `yaml:"limits,omitempty" validate:"dive"`
 	LimitsPreset string         `yaml:"limits_preset,omitempty"`
+	// DirectoriesPreset, UsersGroupsPreset, PackagesPreset, BundlePreset:
+	// plan 033 conventions library. Resolved at config-load time (bundle)
+	// and per-manager Plan() (individual *_preset fields).
+	DirectoriesPreset string `yaml:"directories_preset,omitempty"`
+	UsersGroupsPreset string `yaml:"users_groups_preset,omitempty"`
+	PackagesPreset    string `yaml:"packages_preset,omitempty"`
+	BundlePreset      string `yaml:"bundle_preset,omitempty"`
 	Firewall     *Firewall      `yaml:"firewall,omitempty"`
 	HostsEntries []HostEntry    `yaml:"hosts_entries,omitempty" validate:"dive"`
 	Services     []ServiceState `yaml:"services,omitempty" validate:"dive"`

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -8,8 +8,50 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// BundleExpander is an optional hook that pkg/presets wires into the loader
+// to expand `bundle_preset` into per-category *_preset fields. The loader
+// stays free of a pkg/presets import to avoid a cycle; pkg/presets calls
+// RegisterBundleExpander() in its init().
+type BundleExpander func(name string) (map[string]string, error)
+
+var bundleExpander BundleExpander
+
+// RegisterBundleExpander wires an expander. pkg/presets calls this from init.
+func RegisterBundleExpander(fn BundleExpander) { bundleExpander = fn }
+
+// expandBundleOnLinux fills the per-category *_preset fields from the named
+// bundle, but only for fields the user left empty. Explicit per-category
+// presets always win over the bundle.
+func expandBundleOnLinux(l *Linux) error {
+	if l == nil || l.BundlePreset == "" || bundleExpander == nil {
+		return nil
+	}
+	children, err := bundleExpander(l.BundlePreset)
+	if err != nil {
+		return fmt.Errorf("bundle %q: %w", l.BundlePreset, err)
+	}
+	if l.DirectoriesPreset == "" {
+		l.DirectoriesPreset = children["directories"]
+	}
+	if l.UsersGroupsPreset == "" {
+		l.UsersGroupsPreset = children["users_groups"]
+	}
+	if l.PackagesPreset == "" {
+		l.PackagesPreset = children["packages"]
+	}
+	if l.SysctlPreset == "" {
+		l.SysctlPreset = children["sysctl"]
+	}
+	if l.LimitsPreset == "" {
+		l.LimitsPreset = children["limits"]
+	}
+	return nil
+}
+
 // LoadLinux reads and decodes a linux.yaml from disk without validation.
-// An empty path returns an empty Linux (scaffold behaviour).
+// If the manifest declares `bundle_preset:`, the bundle is expanded into
+// the per-category *_preset fields (user overrides always win). An empty
+// path returns an empty Linux (scaffold behaviour).
 func LoadLinux(path string) (*Linux, error) {
 	if path == "" {
 		return &Linux{}, nil
@@ -21,6 +63,9 @@ func LoadLinux(path string) (*Linux, error) {
 	var l Linux
 	if err := yaml.Unmarshal(b, &l); err != nil {
 		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	if err := expandBundleOnLinux(&l); err != nil {
+		return nil, fmt.Errorf("%s: %w", path, err)
 	}
 	return &l, nil
 }
@@ -65,6 +110,13 @@ func LoadEnv(path string, r *Resolver) (*Env, error) {
 		env.Spec.Linux.Value = l
 	} else if env.Spec.Linux.Inline != nil {
 		env.Spec.Linux.Value = env.Spec.Linux.Inline
+	}
+
+	// Expand bundle_preset on the resolved Linux manifest (if any).
+	if env.Spec.Linux.Value != nil {
+		if err := expandBundleOnLinux(env.Spec.Linux.Value); err != nil {
+			return nil, err
+		}
 	}
 
 	// Resolve secret placeholders.

--- a/pkg/managers/dir.go
+++ b/pkg/managers/dir.go
@@ -3,10 +3,12 @@ package managers
 import (
 	"context"
 	"fmt"
+	"log"
 	"strconv"
 	"strings"
 
 	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 	"github.com/itunified-io/linuxctl/pkg/session"
 )
 
@@ -236,8 +238,12 @@ func (m *DirManager) Rollback(ctx context.Context, changes []Change) error {
 }
 
 // castDirectories accepts either []config.Directory, *config.Linux, or a
-// generic Spec carrying Directories.
+// generic Spec carrying Directories. When a *config.Linux carries a
+// DirectoriesPreset, the preset entries are merged with explicit entries
+// (explicit wins on path collision).
 func castDirectories(desired Spec) ([]config.Directory, error) {
+	var explicit []config.Directory
+	var presetName string
 	switch v := desired.(type) {
 	case []config.Directory:
 		return v, nil
@@ -245,12 +251,28 @@ func castDirectories(desired Spec) ([]config.Directory, error) {
 		if v == nil {
 			return nil, nil
 		}
-		return v.Directories, nil
+		explicit = v.Directories
+		presetName = v.DirectoriesPreset
 	case config.Linux:
-		return v.Directories, nil
+		explicit = v.Directories
+		presetName = v.DirectoriesPreset
 	case nil:
 		return nil, nil
 	default:
 		return nil, fmt.Errorf("dir: unsupported desired-state type %T", desired)
 	}
+	if presetName == "" {
+		return explicit, nil
+	}
+	p, err := presets.ResolveCategory("directories", presetName, nil)
+	if err != nil {
+		log.Printf("dir: preset %q: %v", presetName, err)
+		return explicit, nil
+	}
+	pdirs, err := presets.DirectoriesSpec(p)
+	if err != nil {
+		log.Printf("dir: preset %q decode: %v", presetName, err)
+		return explicit, nil
+	}
+	return presets.MergeDirectories(explicit, pdirs), nil
 }

--- a/pkg/managers/limits.go
+++ b/pkg/managers/limits.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 	"github.com/itunified-io/linuxctl/pkg/session"
 )
 
@@ -39,33 +40,22 @@ func init() { Register(NewLimitsManager()) }
 
 // ---- Preset ---------------------------------------------------------------
 
-// presetLimits returns hardcoded limits entries for a named preset.
+// presetLimits resolves a named limits preset via the pkg/presets registry.
 func presetLimits(name string) []config.LimitEntry {
-	switch name {
-	case "":
-		return nil
-	case "oracle-19c":
-		var out []config.LimitEntry
-		for _, user := range []string{"grid", "oracle"} {
-			out = append(out,
-				config.LimitEntry{User: user, Type: "soft", Item: "nofile", Value: "1024"},
-				config.LimitEntry{User: user, Type: "hard", Item: "nofile", Value: "65536"},
-				config.LimitEntry{User: user, Type: "soft", Item: "nproc", Value: "16384"},
-				config.LimitEntry{User: user, Type: "hard", Item: "nproc", Value: "16384"},
-				config.LimitEntry{User: user, Type: "soft", Item: "stack", Value: "10240"},
-				config.LimitEntry{User: user, Type: "hard", Item: "stack", Value: "32768"},
-				config.LimitEntry{User: user, Type: "soft", Item: "memlock", Value: "134217728"},
-				config.LimitEntry{User: user, Type: "hard", Item: "memlock", Value: "134217728"},
-			)
-		}
-		return out
-	case "pg-16", "hardened-cis":
-		log.Printf("limits: preset %q not yet populated; Phase 4b", name)
-		return nil
-	default:
-		log.Printf("limits: unknown preset %q", name)
+	if name == "" {
 		return nil
 	}
+	p, err := presets.ResolveCategory("limits", name, nil)
+	if err != nil {
+		log.Printf("limits: preset %q: %v", name, err)
+		return nil
+	}
+	entries, err := presets.LimitsSpec(p)
+	if err != nil {
+		log.Printf("limits: preset %q decode: %v", name, err)
+		return nil
+	}
+	return entries
 }
 
 // limitKey uniquely identifies a limit row for dedup / merge.

--- a/pkg/managers/limits_test.go
+++ b/pkg/managers/limits_test.go
@@ -20,8 +20,9 @@ func TestLimits_PresetExpansion(t *testing.T) {
 	if users["grid"] != 8 || users["oracle"] != 8 {
 		t.Errorf("expected 8 entries per user, got %+v", users)
 	}
-	if got := presetLimits("pg-16"); got != nil {
-		t.Errorf("pg-16 should stub to nil, got %d", len(got))
+	// pg-16 now ships real content via the conventions library (plan 033).
+	if got := presetLimits("pg-16"); len(got) == 0 {
+		t.Errorf("pg-16 should now be populated (plan 033), got %d", len(got))
 	}
 	if got := presetLimits(""); got != nil {
 		t.Error("empty preset should yield nil")

--- a/pkg/managers/package.go
+++ b/pkg/managers/package.go
@@ -3,8 +3,12 @@ package managers
 import (
 	"context"
 	"fmt"
+	"log"
 	"strings"
 	"time"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 )
 
 // PackagesSpec is the desired state for the package manager. Install and
@@ -367,6 +371,10 @@ func containsAny(haystack string, needles ...string) bool {
 	return false
 }
 
+// castPackages normalises a desired Spec into a PackagesSpec. When a
+// *config.Linux is supplied and PackagesPreset is set, the preset is merged
+// with explicit package lists (union of Install + Remove, explicit wins on
+// install/remove conflict).
 func castPackages(desired Spec) (PackagesSpec, error) {
 	switch v := desired.(type) {
 	case PackagesSpec:
@@ -376,9 +384,36 @@ func castPackages(desired Spec) (PackagesSpec, error) {
 			return PackagesSpec{}, nil
 		}
 		return *v, nil
+	case *config.Linux:
+		if v == nil {
+			return PackagesSpec{}, nil
+		}
+		return packagesFromLinux(v), nil
+	case config.Linux:
+		return packagesFromLinux(&v), nil
 	case nil:
 		return PackagesSpec{}, nil
 	default:
 		return PackagesSpec{}, fmt.Errorf("package: unsupported desired-state type %T", desired)
 	}
+}
+
+func packagesFromLinux(l *config.Linux) PackagesSpec {
+	explicit := config.Packages{}
+	if l.Packages != nil {
+		explicit = *l.Packages
+	}
+	merged := explicit
+	if l.PackagesPreset != "" {
+		if p, err := presets.ResolveCategory("packages", l.PackagesPreset, nil); err == nil {
+			if pp, err := presets.PackagesSpec(p); err == nil && pp != nil {
+				merged = presets.MergePackages(explicit, *pp)
+			} else if err != nil {
+				log.Printf("package: preset %q decode: %v", l.PackagesPreset, err)
+			}
+		} else {
+			log.Printf("package: preset %q: %v", l.PackagesPreset, err)
+		}
+	}
+	return PackagesSpec{Install: merged.Install, Remove: merged.Remove}
 }

--- a/pkg/managers/sysctl.go
+++ b/pkg/managers/sysctl.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 	"github.com/itunified-io/linuxctl/pkg/session"
 )
 
@@ -40,33 +41,24 @@ func init() { Register(NewSysctlManager()) }
 
 // ---- Preset expansion ------------------------------------------------------
 
-// presetSysctl returns the hardcoded sysctl entries for a named preset. Returns
-// nil + false when the preset is unknown. The Oracle 19c preset ships with
-// published Oracle RDBMS pre-install kernel params.
+// presetSysctl resolves a named sysctl preset via the pkg/presets registry.
+// Unknown / business-gated presets return nil + log; the manager then
+// proceeds with only the explicit entries (if any).
 func presetSysctl(name string) []config.SysctlEntry {
-	switch name {
-	case "":
-		return nil
-	case "oracle-19c":
-		return []config.SysctlEntry{
-			{Key: "fs.aio-max-nr", Value: "1048576"},
-			{Key: "fs.file-max", Value: "6815744"},
-			{Key: "kernel.panic_on_oops", Value: "1"},
-			{Key: "kernel.sem", Value: "250 32000 100 128"},
-			{Key: "kernel.shmall", Value: "1073741824"},
-			{Key: "kernel.shmmax", Value: "4398046511104"},
-			{Key: "kernel.shmmni", Value: "4096"},
-			{Key: "net.core.rmem_max", Value: "4194304"},
-			{Key: "net.core.wmem_max", Value: "1048576"},
-			{Key: "vm.swappiness", Value: "10"},
-		}
-	case "pg-16", "hardened-cis":
-		log.Printf("sysctl: preset %q not yet populated; Phase 4b", name)
-		return nil
-	default:
-		log.Printf("sysctl: unknown preset %q", name)
+	if name == "" {
 		return nil
 	}
+	p, err := presets.ResolveCategory("sysctl", name, nil)
+	if err != nil {
+		log.Printf("sysctl: preset %q: %v", name, err)
+		return nil
+	}
+	entries, err := presets.SysctlSpec(p)
+	if err != nil {
+		log.Printf("sysctl: preset %q decode: %v", name, err)
+		return nil
+	}
+	return entries
 }
 
 // mergeSysctl merges explicit entries with a preset's entries. Explicit wins

--- a/pkg/managers/sysctl_test.go
+++ b/pkg/managers/sysctl_test.go
@@ -104,8 +104,9 @@ func TestSysctl_PresetExpansion(t *testing.T) {
 			t.Errorf("preset missing %q", req)
 		}
 	}
-	if got := presetSysctl("pg-16"); got != nil {
-		t.Errorf("pg-16 should stub to nil, got %d entries", len(got))
+	// pg-16 now ships real content via the conventions library (plan 033).
+	if got := presetSysctl("pg-16"); len(got) == 0 {
+		t.Errorf("pg-16 should now be populated (plan 033), got %d entries", len(got))
 	}
 	if got := presetSysctl("unknown"); got != nil {
 		t.Errorf("unknown should be nil, got %v", got)

--- a/pkg/managers/user.go
+++ b/pkg/managers/user.go
@@ -3,9 +3,13 @@ package managers
 import (
 	"context"
 	"fmt"
+	"log"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/presets"
 )
 
 // SessionRunner is the minimal command-execution contract that the User and
@@ -526,9 +530,9 @@ func (m *UserManager) runOut(ctx context.Context, cmd string) (string, string, e
 	return m.sess.Run(ctx, cmd)
 }
 
-// castUsersGroups accepts either the concrete typed spec or a generic map
-// (unmarshaled YAML). It keeps the manager forward-compatible with whatever
-// representation pkg/config ends up settling on.
+// castUsersGroups accepts either the concrete typed spec, *config.Linux,
+// or a generic map (unmarshaled YAML). When a *config.Linux carries a
+// UsersGroupsPreset, the preset is merged with explicit entries.
 func castUsersGroups(desired Spec) (UsersGroupsSpec, error) {
 	switch v := desired.(type) {
 	case UsersGroupsSpec:
@@ -538,11 +542,57 @@ func castUsersGroups(desired Spec) (UsersGroupsSpec, error) {
 			return UsersGroupsSpec{}, nil
 		}
 		return *v, nil
+	case *config.Linux:
+		if v == nil {
+			return UsersGroupsSpec{}, nil
+		}
+		return usersGroupsFromLinux(v), nil
+	case config.Linux:
+		return usersGroupsFromLinux(&v), nil
 	case nil:
 		return UsersGroupsSpec{}, nil
 	default:
 		return UsersGroupsSpec{}, fmt.Errorf("user: unsupported desired-state type %T", desired)
 	}
+}
+
+// usersGroupsFromLinux converts the config.Linux users_groups block into the
+// manager's UsersGroupsSpec shape, applying preset merging if
+// UsersGroupsPreset is set.
+func usersGroupsFromLinux(l *config.Linux) UsersGroupsSpec {
+	explicit := config.UsersGroups{}
+	if l.UsersGroups != nil {
+		explicit = *l.UsersGroups
+	}
+	merged := explicit
+	if l.UsersGroupsPreset != "" {
+		if p, err := presets.ResolveCategory("users_groups", l.UsersGroupsPreset, nil); err == nil {
+			if pug, err := presets.UsersGroupsSpec(p); err == nil && pug != nil {
+				merged = presets.MergeUsersGroups(explicit, *pug)
+			} else if err != nil {
+				log.Printf("user: preset %q decode: %v", l.UsersGroupsPreset, err)
+			}
+		} else {
+			log.Printf("user: preset %q: %v", l.UsersGroupsPreset, err)
+		}
+	}
+	out := UsersGroupsSpec{}
+	for _, g := range merged.Groups {
+		out.Groups = append(out.Groups, GroupSpec{Name: g.Name, GID: g.GID})
+	}
+	for _, u := range merged.Users {
+		out.Users = append(out.Users, UserSpec{
+			Name:     u.Name,
+			UID:      u.UID,
+			GID:      u.GID,
+			Groups:   u.Groups,
+			Home:     u.Home,
+			Shell:    u.Shell,
+			SSHKeys:  u.SSHKeys,
+			Password: u.Password,
+		})
+	}
+	return out
 }
 
 // shellQuote wraps s in single quotes, escaping any embedded single quote.

--- a/pkg/presets/data/.keep
+++ b/pkg/presets/data/.keep
@@ -1,0 +1,1 @@
+# Preset data lives here. See pkg/presets/embed.go.

--- a/pkg/presets/data/bundles/minimal-host.yaml
+++ b/pkg/presets/data/bundles/minimal-host.yaml
@@ -1,0 +1,11 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: minimal-host
+  category: bundles
+  tier: community
+  source: "Minimal host baseline (no DB). Only ensures cifs-utils is installed."
+  version: "2026-04-22"
+spec:
+  bundle:
+    packages_preset: minimal-host

--- a/pkg/presets/data/bundles/oracle-rac-19c.yaml
+++ b/pkg/presets/data/bundles/oracle-rac-19c.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: oracle-rac-19c
+  category: bundles
+  tier: community
+  source: "Oracle Database 19c RAC baseline (OFA + RAC users + preinstall + sysctl/limits)"
+  version: "2026-04-22"
+spec:
+  bundle:
+    directories_preset: oracle-ofa-19c
+    users_groups_preset: oracle-rac
+    packages_preset: oracle-19c
+    sysctl_preset: oracle-19c
+    limits_preset: oracle-19c

--- a/pkg/presets/data/bundles/oracle-rac-23ai.yaml
+++ b/pkg/presets/data/bundles/oracle-rac-23ai.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: oracle-rac-23ai
+  category: bundles
+  tier: community
+  source: "Oracle Database 23ai RAC baseline (sysctl/limits reuse 19c values until Oracle publishes 23ai-specific guidance)"
+  version: "2026-04-22"
+spec:
+  bundle:
+    directories_preset: oracle-ofa-23ai
+    users_groups_preset: oracle-rac
+    packages_preset: oracle-23ai
+    sysctl_preset: oracle-19c
+    limits_preset: oracle-19c

--- a/pkg/presets/data/bundles/oracle-single-19c.yaml
+++ b/pkg/presets/data/bundles/oracle-single-19c.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: oracle-single-19c
+  category: bundles
+  tier: community
+  source: "Oracle Database 19c single-instance baseline"
+  version: "2026-04-22"
+spec:
+  bundle:
+    directories_preset: oracle-ofa-19c
+    users_groups_preset: oracle-single
+    packages_preset: oracle-19c
+    sysctl_preset: oracle-19c
+    limits_preset: oracle-19c

--- a/pkg/presets/data/bundles/pg-single-16.yaml
+++ b/pkg/presets/data/bundles/pg-single-16.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: pg-single-16
+  category: bundles
+  tier: community
+  source: "PostgreSQL 16 single-instance baseline"
+  version: "2026-04-22"
+spec:
+  bundle:
+    directories_preset: pg-ofa-16
+    users_groups_preset: pg-user
+    packages_preset: pg-16
+    sysctl_preset: pg-16
+    limits_preset: pg-16

--- a/pkg/presets/data/directories/oracle-ofa-19c.yaml
+++ b/pkg/presets/data/directories/oracle-ofa-19c.yaml
@@ -1,0 +1,18 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-ofa-19c
+  category: directories
+  tier: community
+  source: "Oracle Database 19c Installation Guide for Linux, Appendix B (OFA)"
+  version: "2026-04-22"
+spec:
+  directories:
+    - { path: "/u01/app/oracle",                          owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product",                  owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product/19.0.0",           owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product/19.0.0/dbhome_1",  owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/grid",                            owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/19.0.0",                          owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/19.0.0/grid",                     owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oraInventory",                    owner: "grid",   group: "oinstall", mode: "0770" }

--- a/pkg/presets/data/directories/oracle-ofa-23ai.yaml
+++ b/pkg/presets/data/directories/oracle-ofa-23ai.yaml
@@ -1,0 +1,18 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-ofa-23ai
+  category: directories
+  tier: community
+  source: "Oracle Database 23ai Installation Guide for Linux (OFA)"
+  version: "2026-04-22"
+spec:
+  directories:
+    - { path: "/u01/app/oracle",                          owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product",                  owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product/23.0.0",           owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oracle/product/23.0.0/dbhome_1",  owner: "oracle", group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/grid",                            owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/23.0.0",                          owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/23.0.0/grid",                     owner: "grid",   group: "oinstall", mode: "0775" }
+    - { path: "/u01/app/oraInventory",                    owner: "grid",   group: "oinstall", mode: "0770" }

--- a/pkg/presets/data/directories/pg-ofa-16.yaml
+++ b/pkg/presets/data/directories/pg-ofa-16.yaml
@@ -1,0 +1,18 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: pg-ofa-16
+  category: directories
+  tier: community
+  source: "PostgreSQL 16 packaging conventions (PGDG Debian/RHEL)"
+  version: "2026-04-22"
+spec:
+  directories:
+    # PGDG convention: /var/lib/pgsql/16/data on RHEL,
+    # /var/lib/postgresql/16/main on Debian — we ship the RHEL layout by
+    # default; Debian stacks can override via explicit directories.
+    - { path: "/var/lib/pgsql",                owner: "postgres", group: "postgres", mode: "0700" }
+    - { path: "/var/lib/pgsql/16",             owner: "postgres", group: "postgres", mode: "0700" }
+    - { path: "/var/lib/pgsql/16/data",        owner: "postgres", group: "postgres", mode: "0700" }
+    - { path: "/var/lib/pgsql/16/backups",     owner: "postgres", group: "postgres", mode: "0700" }
+    - { path: "/var/log/postgresql",           owner: "postgres", group: "postgres", mode: "0755" }

--- a/pkg/presets/data/limits/oracle-19c.yaml
+++ b/pkg/presets/data/limits/oracle-19c.yaml
@@ -1,0 +1,26 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-19c
+  category: limits
+  tier: community
+  source: "Oracle Database 19c pre-install resource limits (migrated from pkg/managers/limits.go)"
+  version: "2026-04-22"
+spec:
+  limits:
+    - { user: "grid",   type: "soft", item: "nofile",  value: "1024" }
+    - { user: "grid",   type: "hard", item: "nofile",  value: "65536" }
+    - { user: "grid",   type: "soft", item: "nproc",   value: "16384" }
+    - { user: "grid",   type: "hard", item: "nproc",   value: "16384" }
+    - { user: "grid",   type: "soft", item: "stack",   value: "10240" }
+    - { user: "grid",   type: "hard", item: "stack",   value: "32768" }
+    - { user: "grid",   type: "soft", item: "memlock", value: "134217728" }
+    - { user: "grid",   type: "hard", item: "memlock", value: "134217728" }
+    - { user: "oracle", type: "soft", item: "nofile",  value: "1024" }
+    - { user: "oracle", type: "hard", item: "nofile",  value: "65536" }
+    - { user: "oracle", type: "soft", item: "nproc",   value: "16384" }
+    - { user: "oracle", type: "hard", item: "nproc",   value: "16384" }
+    - { user: "oracle", type: "soft", item: "stack",   value: "10240" }
+    - { user: "oracle", type: "hard", item: "stack",   value: "32768" }
+    - { user: "oracle", type: "soft", item: "memlock", value: "134217728" }
+    - { user: "oracle", type: "hard", item: "memlock", value: "134217728" }

--- a/pkg/presets/data/limits/pg-16.yaml
+++ b/pkg/presets/data/limits/pg-16.yaml
@@ -1,0 +1,16 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: pg-16
+  category: limits
+  tier: community
+  source: "PostgreSQL 16 recommended ulimits for the postgres user"
+  version: "2026-04-22"
+spec:
+  limits:
+    - { user: "postgres", type: "soft", item: "nofile",  value: "8192" }
+    - { user: "postgres", type: "hard", item: "nofile",  value: "65536" }
+    - { user: "postgres", type: "soft", item: "nproc",   value: "8192" }
+    - { user: "postgres", type: "hard", item: "nproc",   value: "16384" }
+    - { user: "postgres", type: "soft", item: "memlock", value: "unlimited" }
+    - { user: "postgres", type: "hard", item: "memlock", value: "unlimited" }

--- a/pkg/presets/data/packages/minimal-host.yaml
+++ b/pkg/presets/data/packages/minimal-host.yaml
@@ -1,0 +1,12 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: minimal-host
+  category: packages
+  tier: community
+  source: "Minimal host package baseline (CIFS client for software mounts)"
+  version: "2026-04-22"
+spec:
+  packages:
+    install:
+      - cifs-utils

--- a/pkg/presets/data/packages/oracle-19c.yaml
+++ b/pkg/presets/data/packages/oracle-19c.yaml
@@ -1,0 +1,14 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-19c
+  category: packages
+  tier: community
+  source: "Oracle Linux oracle-database-preinstall-19c metapackage + kmod-oracleasm"
+  version: "2026-04-22"
+spec:
+  packages:
+    install:
+      - oracle-database-preinstall-19c
+      - kmod-oracleasm
+      - cifs-utils

--- a/pkg/presets/data/packages/oracle-23ai.yaml
+++ b/pkg/presets/data/packages/oracle-23ai.yaml
@@ -1,0 +1,16 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-23ai
+  category: packages
+  tier: community
+  source: "Oracle Linux oracle-database-preinstall-23ai metapackage"
+  version: "2026-04-22"
+spec:
+  packages:
+    install:
+      # TODO: oracle-database-preinstall-23ai is the target — confirm final
+      # metapackage name after Oracle 23ai GA for non-Oracle-Linux distros.
+      - oracle-database-preinstall-23ai
+      - kmod-oracleasm
+      - cifs-utils

--- a/pkg/presets/data/packages/pg-16.yaml
+++ b/pkg/presets/data/packages/pg-16.yaml
@@ -1,0 +1,14 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: pg-16
+  category: packages
+  tier: community
+  source: "PostgreSQL 16 PGDG packages (RHEL-flavored names; Debian stacks override)"
+  version: "2026-04-22"
+spec:
+  packages:
+    install:
+      - postgresql16
+      - postgresql16-server
+      - postgresql16-contrib

--- a/pkg/presets/data/sysctl/oracle-19c.yaml
+++ b/pkg/presets/data/sysctl/oracle-19c.yaml
@@ -1,0 +1,20 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-19c
+  category: sysctl
+  tier: community
+  source: "Oracle Database 19c pre-install kernel parameters (migrated from pkg/managers/sysctl.go)"
+  version: "2026-04-22"
+spec:
+  sysctl:
+    - { key: "fs.aio-max-nr",        value: "1048576" }
+    - { key: "fs.file-max",          value: "6815744" }
+    - { key: "kernel.panic_on_oops", value: "1" }
+    - { key: "kernel.sem",           value: "250 32000 100 128" }
+    - { key: "kernel.shmall",        value: "1073741824" }
+    - { key: "kernel.shmmax",        value: "4398046511104" }
+    - { key: "kernel.shmmni",        value: "4096" }
+    - { key: "net.core.rmem_max",    value: "4194304" }
+    - { key: "net.core.wmem_max",    value: "1048576" }
+    - { key: "vm.swappiness",        value: "10" }

--- a/pkg/presets/data/sysctl/pg-16.yaml
+++ b/pkg/presets/data/sysctl/pg-16.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: pg-16
+  category: sysctl
+  tier: community
+  source: "PostgreSQL 16 tuned conventions (kernel shmem + huge-page friendly)"
+  version: "2026-04-22"
+spec:
+  sysctl:
+    - { key: "kernel.shmmax",    value: "68719476736" }
+    - { key: "kernel.shmall",    value: "4294967296" }
+    - { key: "vm.swappiness",    value: "10" }
+    - { key: "vm.overcommit_memory", value: "2" }
+    - { key: "vm.overcommit_ratio",  value: "80" }

--- a/pkg/presets/data/users_groups/oracle-rac.yaml
+++ b/pkg/presets/data/users_groups/oracle-rac.yaml
@@ -1,0 +1,20 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-rac
+  category: users_groups
+  tier: community
+  source: "Oracle Database 19c/21c/23ai RAC Install Guide — pre-install user/group matrix"
+  version: "2026-04-22"
+spec:
+  users_groups:
+    groups:
+      - { name: "oinstall", gid: 54321 }
+      - { name: "dba",      gid: 54322 }
+      - { name: "asmadmin", gid: 54331 }
+      - { name: "asmdba",   gid: 54332 }
+      - { name: "asmoper",  gid: 54333 }
+      - { name: "racdba",   gid: 54334 }
+    users:
+      - { name: "oracle", uid: 54321, gid: "oinstall", groups: ["dba", "asmdba"] }
+      - { name: "grid",   uid: 54322, gid: "oinstall", groups: ["dba", "asmadmin", "asmdba", "asmoper", "racdba"] }

--- a/pkg/presets/data/users_groups/oracle-single.yaml
+++ b/pkg/presets/data/users_groups/oracle-single.yaml
@@ -1,0 +1,15 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: oracle-single
+  category: users_groups
+  tier: community
+  source: "Oracle Database single-instance install: simplified user/group set (no ASM/RAC groups)"
+  version: "2026-04-22"
+spec:
+  users_groups:
+    groups:
+      - { name: "oinstall", gid: 54321 }
+      - { name: "dba",      gid: 54322 }
+    users:
+      - { name: "oracle", uid: 54321, gid: "oinstall", groups: ["dba"] }

--- a/pkg/presets/data/users_groups/pg-user.yaml
+++ b/pkg/presets/data/users_groups/pg-user.yaml
@@ -1,0 +1,14 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: pg-user
+  category: users_groups
+  tier: community
+  source: "PostgreSQL PGDG packaging — postgres system user/group"
+  version: "2026-04-22"
+spec:
+  users_groups:
+    groups:
+      - { name: "postgres", gid: 26 }
+    users:
+      - { name: "postgres", uid: 26, gid: "postgres", home: "/var/lib/pgsql", shell: "/bin/bash" }

--- a/pkg/presets/embed.go
+++ b/pkg/presets/embed.go
@@ -1,0 +1,113 @@
+package presets
+
+import (
+	"embed"
+	"fmt"
+	"io/fs"
+	"path"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// embeddedFS holds every preset YAML shipped with the binary.
+//
+//go:embed all:data
+var embeddedFS embed.FS
+
+// index is the parsed in-memory catalog. Populated lazily by load().
+type index struct {
+	byName   map[string]*Preset
+	bundles  map[string]*Bundle
+	meta     []PresetMeta
+}
+
+var (
+	loadOnce sync.Once
+	loaded   *index
+	loadErr  error
+)
+
+// load reads every *.yaml under data/ exactly once and caches the result.
+func load() (*index, error) {
+	loadOnce.Do(func() {
+		idx := &index{
+			byName:  map[string]*Preset{},
+			bundles: map[string]*Bundle{},
+		}
+		err := fs.WalkDir(embeddedFS, "data", func(p string, d fs.DirEntry, werr error) error {
+			if werr != nil {
+				return werr
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if !strings.HasSuffix(p, ".yaml") && !strings.HasSuffix(p, ".yml") {
+				return nil
+			}
+			b, rerr := embeddedFS.ReadFile(p)
+			if rerr != nil {
+				return fmt.Errorf("read %s: %w", p, rerr)
+			}
+			var pr Preset
+			if derr := yaml.Unmarshal(b, &pr); derr != nil {
+				return fmt.Errorf("parse %s: %w", p, derr)
+			}
+			if pr.Metadata.Name == "" {
+				return fmt.Errorf("%s: metadata.name is required", p)
+			}
+			// Infer category from parent dir if not set (defensive).
+			if pr.Metadata.Category == "" {
+				pr.Metadata.Category = path.Base(path.Dir(p))
+			}
+			// Default tier.
+			if pr.Metadata.Tier == "" {
+				pr.Metadata.Tier = TierCommunity
+			}
+			// Filename must match metadata.name (bisect-friendly).
+			fn := strings.TrimSuffix(path.Base(p), path.Ext(p))
+			if fn != pr.Metadata.Name {
+				return fmt.Errorf("%s: filename %q != metadata.name %q", p, fn, pr.Metadata.Name)
+			}
+			if _, exists := idx.byName[pr.Metadata.Name]; exists {
+				return fmt.Errorf("duplicate preset name %q (file %s)", pr.Metadata.Name, p)
+			}
+			idx.byName[pr.Metadata.Name] = &pr
+			idx.meta = append(idx.meta, pr.Metadata)
+			if pr.Kind == "Bundle" {
+				bundle, berr := decodeBundle(&pr)
+				if berr != nil {
+					return fmt.Errorf("%s: %w", p, berr)
+				}
+				idx.bundles[pr.Metadata.Name] = bundle
+			}
+			return nil
+		})
+		if err != nil {
+			loadErr = err
+			return
+		}
+		loaded = idx
+	})
+	return loaded, loadErr
+}
+
+// decodeBundle extracts the bundle child-preset names from a Preset with
+// Kind == "Bundle".
+func decodeBundle(pr *Preset) (*Bundle, error) {
+	raw, ok := pr.RawSpec["bundle"]
+	if !ok {
+		return nil, fmt.Errorf("bundle %q: spec.bundle missing", pr.Metadata.Name)
+	}
+	// Round-trip through YAML for strict typed decoding.
+	b, err := yaml.Marshal(raw)
+	if err != nil {
+		return nil, err
+	}
+	var out Bundle
+	if err := yaml.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}

--- a/pkg/presets/embed.go
+++ b/pkg/presets/embed.go
@@ -17,11 +17,19 @@ import (
 var embeddedFS embed.FS
 
 // index is the parsed in-memory catalog. Populated lazily by load().
+//
+// Presets are keyed by "category/name" because the same short name (e.g.
+// "oracle-19c") is legitimately reused across categories (packages + sysctl +
+// limits). Bundles reference child presets by name + category from the
+// bundle spec, so the registry resolves them unambiguously.
 type index struct {
-	byName   map[string]*Preset
-	bundles  map[string]*Bundle
-	meta     []PresetMeta
+	byKey   map[string]*Preset // "category/name" → preset
+	byName  map[string][]*Preset // "name" → all presets with that name (across categories)
+	bundles map[string]*Bundle
+	meta    []PresetMeta
 }
+
+func catKey(category, name string) string { return category + "/" + name }
 
 var (
 	loadOnce sync.Once
@@ -33,7 +41,8 @@ var (
 func load() (*index, error) {
 	loadOnce.Do(func() {
 		idx := &index{
-			byName:  map[string]*Preset{},
+			byKey:   map[string]*Preset{},
+			byName:  map[string][]*Preset{},
 			bundles: map[string]*Bundle{},
 		}
 		err := fs.WalkDir(embeddedFS, "data", func(p string, d fs.DirEntry, werr error) error {
@@ -70,10 +79,12 @@ func load() (*index, error) {
 			if fn != pr.Metadata.Name {
 				return fmt.Errorf("%s: filename %q != metadata.name %q", p, fn, pr.Metadata.Name)
 			}
-			if _, exists := idx.byName[pr.Metadata.Name]; exists {
-				return fmt.Errorf("duplicate preset name %q (file %s)", pr.Metadata.Name, p)
+			key := catKey(pr.Metadata.Category, pr.Metadata.Name)
+			if _, exists := idx.byKey[key]; exists {
+				return fmt.Errorf("duplicate preset %q (file %s)", key, p)
 			}
-			idx.byName[pr.Metadata.Name] = &pr
+			idx.byKey[key] = &pr
+			idx.byName[pr.Metadata.Name] = append(idx.byName[pr.Metadata.Name], &pr)
 			idx.meta = append(idx.meta, pr.Metadata)
 			if pr.Kind == "Bundle" {
 				bundle, berr := decodeBundle(&pr)

--- a/pkg/presets/loader_hook.go
+++ b/pkg/presets/loader_hook.go
@@ -1,0 +1,12 @@
+package presets
+
+import "github.com/itunified-io/linuxctl/pkg/config"
+
+// init wires the bundle expander into pkg/config at import time. Any code
+// path that imports pkg/presets (managers, CLI) gets automatic bundle
+// expansion during config.LoadLinux / LoadEnv.
+func init() {
+	config.RegisterBundleExpander(func(name string) (map[string]string, error) {
+		return BundleExpand(name, nil)
+	})
+}

--- a/pkg/presets/merge.go
+++ b/pkg/presets/merge.go
@@ -1,0 +1,223 @@
+package presets
+
+import (
+	"sort"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+)
+
+// MergeDirectories merges explicit entries with a preset's entries, deduping
+// by path. Explicit entries win on path collision. Output is sorted by path
+// for deterministic comparison.
+func MergeDirectories(explicit []config.Directory, preset []config.Directory) []config.Directory {
+	byPath := map[string]config.Directory{}
+	for _, p := range preset {
+		byPath[p.Path] = p
+	}
+	for _, e := range explicit {
+		byPath[e.Path] = e
+	}
+	out := make([]config.Directory, 0, len(byPath))
+	for _, v := range byPath {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Path < out[j].Path })
+	return out
+}
+
+// MergeUsersGroups merges explicit groups + users with a preset's, deduping
+// by name. For users, the group list is unioned (preset groups + explicit
+// groups); other user fields are overridden by the explicit entry when set.
+func MergeUsersGroups(explicit config.UsersGroups, preset config.UsersGroups) config.UsersGroups {
+	// Groups: dedup by name, explicit wins.
+	gByName := map[string]config.Group{}
+	for _, g := range preset.Groups {
+		gByName[g.Name] = g
+	}
+	for _, g := range explicit.Groups {
+		gByName[g.Name] = g
+	}
+	groups := make([]config.Group, 0, len(gByName))
+	for _, g := range gByName {
+		groups = append(groups, g)
+	}
+	sort.Slice(groups, func(i, j int) bool { return groups[i].Name < groups[j].Name })
+
+	// Users: explicit wins on all fields, except Groups which is unioned.
+	uByName := map[string]config.User{}
+	presetByName := map[string]config.User{}
+	for _, u := range preset.Users {
+		uByName[u.Name] = u
+		presetByName[u.Name] = u
+	}
+	for _, u := range explicit.Users {
+		if prev, had := presetByName[u.Name]; had {
+			merged := u
+			merged.Groups = unionStrings(prev.Groups, u.Groups)
+			// Fill holes in explicit from preset.
+			if merged.UID == 0 {
+				merged.UID = prev.UID
+			}
+			if merged.GID == "" {
+				merged.GID = prev.GID
+			}
+			if merged.Home == "" {
+				merged.Home = prev.Home
+			}
+			if merged.Shell == "" {
+				merged.Shell = prev.Shell
+			}
+			if len(merged.SSHKeys) == 0 {
+				merged.SSHKeys = prev.SSHKeys
+			}
+			if merged.Password == "" {
+				merged.Password = prev.Password
+			}
+			uByName[u.Name] = merged
+		} else {
+			uByName[u.Name] = u
+		}
+	}
+	users := make([]config.User, 0, len(uByName))
+	for _, u := range uByName {
+		users = append(users, u)
+	}
+	sort.Slice(users, func(i, j int) bool { return users[i].Name < users[j].Name })
+
+	return config.UsersGroups{Groups: groups, Users: users}
+}
+
+// MergePackages merges explicit + preset package lists. Install and Remove
+// sets are unioned; identical names survive only once. If a package appears
+// in both Install and Remove (conflict), the explicit side wins.
+func MergePackages(explicit config.Packages, preset config.Packages) config.Packages {
+	install := unionStrings(preset.Install, explicit.Install)
+	remove := unionStrings(preset.Remove, explicit.Remove)
+
+	// Explicit wins on Install/Remove collision.
+	explicitInstall := map[string]bool{}
+	explicitRemove := map[string]bool{}
+	for _, n := range explicit.Install {
+		explicitInstall[n] = true
+	}
+	for _, n := range explicit.Remove {
+		explicitRemove[n] = true
+	}
+
+	inInstall := map[string]bool{}
+	for _, n := range install {
+		inInstall[n] = true
+	}
+	// Remove any name that appears in both install+remove: explicit wins.
+	cleanInstall := make([]string, 0, len(install))
+	for _, n := range install {
+		if inRemove(remove, n) {
+			if explicitInstall[n] {
+				cleanInstall = append(cleanInstall, n)
+			}
+			continue
+		}
+		cleanInstall = append(cleanInstall, n)
+	}
+	cleanRemove := make([]string, 0, len(remove))
+	for _, n := range remove {
+		if inInstall[n] {
+			if explicitRemove[n] {
+				cleanRemove = append(cleanRemove, n)
+			}
+			continue
+		}
+		cleanRemove = append(cleanRemove, n)
+	}
+
+	// Enabled / DisabledServices: union.
+	enabled := unionStrings(preset.EnabledServices, explicit.EnabledServices)
+	disabled := unionStrings(preset.DisabledServices, explicit.DisabledServices)
+
+	sort.Strings(cleanInstall)
+	sort.Strings(cleanRemove)
+	sort.Strings(enabled)
+	sort.Strings(disabled)
+
+	return config.Packages{
+		Install:          cleanInstall,
+		Remove:           cleanRemove,
+		EnabledServices:  enabled,
+		DisabledServices: disabled,
+	}
+}
+
+// MergeSysctl merges explicit + preset sysctl entries, deduping by key.
+// Explicit wins on key collision. Output is sorted by key.
+func MergeSysctl(explicit []config.SysctlEntry, preset []config.SysctlEntry) []config.SysctlEntry {
+	byKey := map[string]string{}
+	for _, p := range preset {
+		byKey[p.Key] = p.Value
+	}
+	for _, e := range explicit {
+		byKey[e.Key] = e.Value
+	}
+	out := make([]config.SysctlEntry, 0, len(byKey))
+	for k, v := range byKey {
+		out = append(out, config.SysctlEntry{Key: k, Value: v})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Key < out[j].Key })
+	return out
+}
+
+// MergeLimits merges explicit + preset limit entries, deduping by
+// (user, type, item). Explicit wins.
+func MergeLimits(explicit []config.LimitEntry, preset []config.LimitEntry) []config.LimitEntry {
+	key := func(l config.LimitEntry) string { return l.User + "|" + l.Type + "|" + l.Item }
+	byKey := map[string]config.LimitEntry{}
+	for _, p := range preset {
+		byKey[key(p)] = p
+	}
+	for _, e := range explicit {
+		byKey[key(e)] = e
+	}
+	out := make([]config.LimitEntry, 0, len(byKey))
+	for _, v := range byKey {
+		out = append(out, v)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].User != out[j].User {
+			return out[i].User < out[j].User
+		}
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].Item < out[j].Item
+	})
+	return out
+}
+
+// unionStrings returns the stable-order union of two string slices, dedup.
+// Order: a-items first in their input order, then a-missing b-items in their
+// order.
+func unionStrings(a, b []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(a)+len(b))
+	for _, s := range a {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	for _, s := range b {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func inRemove(remove []string, name string) bool {
+	for _, r := range remove {
+		if r == name {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -1,0 +1,178 @@
+package presets
+
+import (
+	"testing"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+)
+
+func TestMergeDirectories_ExplicitWins(t *testing.T) {
+	preset := []config.Directory{
+		{Path: "/u01/app/oracle", Owner: "oracle", Group: "oinstall", Mode: "0775"},
+		{Path: "/smb/software", Owner: "root", Group: "root", Mode: "0755"},
+	}
+	explicit := []config.Directory{
+		{Path: "/smb/software", Owner: "root", Group: "root", Mode: "0700"}, // override
+		{Path: "/opt/custom", Owner: "root", Group: "root", Mode: "0755"},   // new
+	}
+	out := MergeDirectories(explicit, preset)
+	if len(out) != 3 {
+		t.Fatalf("want 3 dirs, got %d: %+v", len(out), out)
+	}
+	// Sorted by path
+	if out[0].Path != "/opt/custom" || out[1].Path != "/smb/software" || out[2].Path != "/u01/app/oracle" {
+		t.Errorf("unexpected ordering: %+v", out)
+	}
+	// Override
+	for _, d := range out {
+		if d.Path == "/smb/software" && d.Mode != "0700" {
+			t.Errorf("explicit did not win: %+v", d)
+		}
+	}
+}
+
+func TestMergeDirectories_Empty(t *testing.T) {
+	if out := MergeDirectories(nil, nil); len(out) != 0 {
+		t.Errorf("want empty, got %+v", out)
+	}
+}
+
+func TestMergeUsersGroups_UnionGroupsExplicitWins(t *testing.T) {
+	preset := config.UsersGroups{
+		Groups: []config.Group{{Name: "oinstall", GID: 54321}, {Name: "dba", GID: 54322}},
+		Users: []config.User{
+			{Name: "oracle", UID: 54321, GID: "oinstall", Groups: []string{"dba"}},
+		},
+	}
+	explicit := config.UsersGroups{
+		Groups: []config.Group{{Name: "wheel", GID: 10}},
+		Users: []config.User{
+			{Name: "oracle", Groups: []string{"extra"}, Shell: "/bin/zsh"},
+			{Name: "alice", Shell: "/bin/bash"},
+		},
+	}
+	out := MergeUsersGroups(explicit, preset)
+	if len(out.Groups) != 3 {
+		t.Errorf("want 3 groups, got %d: %+v", len(out.Groups), out.Groups)
+	}
+	if len(out.Users) != 2 {
+		t.Fatalf("want 2 users, got %+v", out.Users)
+	}
+	var oracle config.User
+	for _, u := range out.Users {
+		if u.Name == "oracle" {
+			oracle = u
+		}
+	}
+	if oracle.UID != 54321 {
+		t.Errorf("oracle UID lost from preset: %+v", oracle)
+	}
+	if oracle.Shell != "/bin/zsh" {
+		t.Errorf("explicit shell did not win: %+v", oracle)
+	}
+	if !containsStr(oracle.Groups, "dba") || !containsStr(oracle.Groups, "extra") {
+		t.Errorf("groups union failed: %+v", oracle.Groups)
+	}
+}
+
+func TestMergeUsersGroups_GroupOverride(t *testing.T) {
+	preset := config.UsersGroups{Groups: []config.Group{{Name: "oinstall", GID: 1000}}}
+	explicit := config.UsersGroups{Groups: []config.Group{{Name: "oinstall", GID: 54321}}}
+	out := MergeUsersGroups(explicit, preset)
+	if len(out.Groups) != 1 || out.Groups[0].GID != 54321 {
+		t.Errorf("explicit should override GID: %+v", out.Groups)
+	}
+}
+
+func TestMergePackages_UnionAndConflict(t *testing.T) {
+	preset := config.Packages{
+		Install: []string{"cifs-utils", "nfs-utils"},
+		Remove:  []string{"telnet"},
+	}
+	explicit := config.Packages{
+		Install: []string{"htop", "nfs-utils"}, // dedup
+		Remove:  []string{"cifs-utils"},        // explicit remove wins over preset install
+	}
+	out := MergePackages(explicit, preset)
+	if containsStr(out.Install, "cifs-utils") {
+		t.Errorf("explicit remove should win over preset install: %+v", out)
+	}
+	if !containsStr(out.Remove, "cifs-utils") {
+		t.Errorf("cifs-utils should be in Remove: %+v", out)
+	}
+	if !containsStr(out.Install, "htop") || !containsStr(out.Install, "nfs-utils") {
+		t.Errorf("install union failed: %+v", out.Install)
+	}
+	if !containsStr(out.Remove, "telnet") {
+		t.Errorf("preset remove lost: %+v", out.Remove)
+	}
+}
+
+func TestMergeSysctl_ExplicitWins(t *testing.T) {
+	preset := []config.SysctlEntry{{Key: "vm.swappiness", Value: "10"}}
+	explicit := []config.SysctlEntry{{Key: "vm.swappiness", Value: "1"}}
+	out := MergeSysctl(explicit, preset)
+	if len(out) != 1 || out[0].Value != "1" {
+		t.Errorf("explicit did not win: %+v", out)
+	}
+}
+
+func TestMergeLimits_ExplicitWins(t *testing.T) {
+	preset := []config.LimitEntry{{User: "oracle", Type: "soft", Item: "nofile", Value: "1024"}}
+	explicit := []config.LimitEntry{{User: "oracle", Type: "soft", Item: "nofile", Value: "4096"}}
+	out := MergeLimits(explicit, preset)
+	if len(out) != 1 || out[0].Value != "4096" {
+		t.Errorf("explicit did not win: %+v", out)
+	}
+}
+
+func TestTierRank_And_Resolve(t *testing.T) {
+	if tierRank(TierCommunity) >= tierRank(TierBusiness) {
+		t.Error("community should rank below business")
+	}
+	if tierRank(TierBusiness) >= tierRank(TierEnterprise) {
+		t.Error("business should rank below enterprise")
+	}
+	if tierRank(Tier("garbage")) != 1 {
+		t.Error("unknown tier should default to community rank")
+	}
+	if resolveTier(nil) != TierCommunity {
+		t.Error("nil fn should default to community")
+	}
+	if resolveTier(func() Tier { return "" }) != TierCommunity {
+		t.Error("empty tier should default to community")
+	}
+	if resolveTier(func() Tier { return TierBusiness }) != TierBusiness {
+		t.Error("tierFn should be honored")
+	}
+}
+
+func TestResolve_EmptyName(t *testing.T) {
+	if _, err := Resolve("", nil); err == nil {
+		t.Error("expected error on empty name")
+	}
+}
+
+func TestResolve_UnknownName(t *testing.T) {
+	if _, err := Resolve("does-not-exist-xxx", nil); err == nil {
+		t.Error("expected error on unknown preset")
+	}
+}
+
+func TestUnionStrings(t *testing.T) {
+	a := []string{"a", "b"}
+	b := []string{"b", "c"}
+	out := unionStrings(a, b)
+	if len(out) != 3 || out[0] != "a" || out[1] != "b" || out[2] != "c" {
+		t.Errorf("union failed: %+v", out)
+	}
+}
+
+func containsStr(s []string, x string) bool {
+	for _, v := range s {
+		if v == x {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -1,7 +1,12 @@
 package presets
 
 import (
+	"io/fs"
+	"path"
+	"strings"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 
 	"github.com/itunified-io/linuxctl/pkg/config"
 )
@@ -165,6 +170,174 @@ func TestUnionStrings(t *testing.T) {
 	out := unionStrings(a, b)
 	if len(out) != 3 || out[0] != "a" || out[1] != "b" || out[2] != "c" {
 		t.Errorf("union failed: %+v", out)
+	}
+}
+
+// ---- Golden tests over embedded YAML -------------------------------------
+
+func TestEmbeddedPresets_AllValid(t *testing.T) {
+	var count int
+	var bundles []string
+	err := fs.WalkDir(embeddedFS, "data", func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() || !strings.HasSuffix(p, ".yaml") {
+			return nil
+		}
+		count++
+		b, rerr := embeddedFS.ReadFile(p)
+		if rerr != nil {
+			t.Errorf("%s: read: %v", p, rerr)
+			return nil
+		}
+		var pr Preset
+		if derr := yaml.Unmarshal(b, &pr); derr != nil {
+			t.Errorf("%s: parse: %v", p, derr)
+			return nil
+		}
+		if pr.Metadata.Name == "" {
+			t.Errorf("%s: missing metadata.name", p)
+		}
+		if pr.Metadata.Version == "" {
+			t.Errorf("%s: missing metadata.version", p)
+		}
+		if pr.Kind != "Preset" && pr.Kind != "Bundle" {
+			t.Errorf("%s: unexpected kind %q", p, pr.Kind)
+		}
+		expectedCategory := path.Base(path.Dir(p))
+		if string(pr.Metadata.Category) != expectedCategory {
+			t.Errorf("%s: category %q does not match parent dir %q", p, pr.Metadata.Category, expectedCategory)
+		}
+		fn := strings.TrimSuffix(path.Base(p), ".yaml")
+		if fn != pr.Metadata.Name {
+			t.Errorf("%s: filename %q does not match metadata.name %q", p, fn, pr.Metadata.Name)
+		}
+		if pr.Kind == "Bundle" {
+			bundles = append(bundles, pr.Metadata.Name)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count < 15 {
+		t.Errorf("expected 15+ shipped presets, got %d", count)
+	}
+	// Bundles reference real presets.
+	for _, bname := range bundles {
+		children, err := BundleExpand(bname, nil)
+		if err != nil {
+			t.Errorf("bundle %q expand: %v", bname, err)
+			continue
+		}
+		for cat, child := range children {
+			if _, err := ResolveCategory(cat, child, nil); err != nil {
+				t.Errorf("bundle %q: %s preset %q not resolvable: %v", bname, cat, child, err)
+			}
+		}
+	}
+}
+
+func TestEmbeddedPresets_Oracle19cSysctlByteForByte(t *testing.T) {
+	// Regression gate: migrated YAML preset must produce identical entries
+	// to the hardcoded Go data it replaces.
+	p, err := ResolveCategory("sysctl", "oracle-19c", func() Tier { return TierCommunity })
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := SysctlSpec(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantKeys := []string{
+		"fs.aio-max-nr", "fs.file-max", "kernel.panic_on_oops",
+		"kernel.sem", "kernel.shmall", "kernel.shmmax", "kernel.shmmni",
+		"net.core.rmem_max", "net.core.wmem_max", "vm.swappiness",
+	}
+	if len(entries) != len(wantKeys) {
+		t.Errorf("oracle-19c sysctl preset: want %d entries, got %d", len(wantKeys), len(entries))
+	}
+	byKey := map[string]string{}
+	for _, e := range entries {
+		byKey[e.Key] = e.Value
+	}
+	want := map[string]string{
+		"fs.aio-max-nr":        "1048576",
+		"fs.file-max":          "6815744",
+		"kernel.panic_on_oops": "1",
+		"kernel.sem":           "250 32000 100 128",
+		"kernel.shmall":        "1073741824",
+		"kernel.shmmax":        "4398046511104",
+		"kernel.shmmni":        "4096",
+		"net.core.rmem_max":    "4194304",
+		"net.core.wmem_max":    "1048576",
+		"vm.swappiness":        "10",
+	}
+	for k, v := range want {
+		if byKey[k] != v {
+			t.Errorf("sysctl preset key %s: want %q, got %q", k, v, byKey[k])
+		}
+	}
+}
+
+func TestEmbeddedPresets_Oracle19cLimitsByteForByte(t *testing.T) {
+	p, err := ResolveCategory("limits", "oracle-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entries, err := LimitsSpec(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 16 {
+		t.Errorf("oracle-19c limits: want 16 entries (2 users * 8), got %d", len(entries))
+	}
+	userCount := map[string]int{}
+	for _, e := range entries {
+		userCount[e.User]++
+	}
+	if userCount["grid"] != 8 || userCount["oracle"] != 8 {
+		t.Errorf("want 8 entries per user, got %+v", userCount)
+	}
+}
+
+func TestResolve_AmbiguousName(t *testing.T) {
+	// oracle-19c exists in packages, sysctl, limits → ambiguous.
+	if _, err := Resolve("oracle-19c", nil); err == nil {
+		t.Error("expected ambiguous error for oracle-19c")
+	}
+}
+
+func TestList_CommunityTier(t *testing.T) {
+	metas := List(func() Tier { return TierCommunity })
+	if len(metas) < 15 {
+		t.Errorf("expected 15+ presets at community tier, got %d", len(metas))
+	}
+}
+
+func TestBundleExpand_OracleRac19c(t *testing.T) {
+	children, err := BundleExpand("oracle-rac-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := map[string]string{
+		"directories":  "oracle-ofa-19c",
+		"users_groups": "oracle-rac",
+		"packages":     "oracle-19c",
+		"sysctl":       "oracle-19c",
+		"limits":       "oracle-19c",
+	}
+	for k, v := range want {
+		if children[k] != v {
+			t.Errorf("bundle child[%s]: want %q, got %q", k, v, children[k])
+		}
+	}
+}
+
+func TestBundleExpand_NotABundle(t *testing.T) {
+	if _, err := BundleExpand("oracle-ofa-19c", nil); err == nil {
+		t.Error("expected error for non-bundle name")
 	}
 }
 

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -341,6 +341,71 @@ func TestBundleExpand_NotABundle(t *testing.T) {
 	}
 }
 
+func TestSpecDecoders(t *testing.T) {
+	// Directories
+	p, err := ResolveCategory("directories", "oracle-ofa-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	dirs, err := DirectoriesSpec(p)
+	if err != nil || len(dirs) == 0 {
+		t.Errorf("DirectoriesSpec: %v len=%d", err, len(dirs))
+	}
+
+	// UsersGroups
+	p, _ = ResolveCategory("users_groups", "oracle-rac", nil)
+	ug, err := UsersGroupsSpec(p)
+	if err != nil || ug == nil || len(ug.Groups) == 0 {
+		t.Errorf("UsersGroupsSpec failed: err=%v ug=%+v", err, ug)
+	}
+
+	// Packages
+	p, _ = ResolveCategory("packages", "oracle-19c", nil)
+	pp, err := PackagesSpec(p)
+	if err != nil || pp == nil || len(pp.Install) == 0 {
+		t.Errorf("PackagesSpec failed: err=%v pp=%+v", err, pp)
+	}
+}
+
+func TestResolveCategory_NotFound(t *testing.T) {
+	if _, err := ResolveCategory("bundles", "nope-xx", nil); err == nil {
+		t.Error("expected error")
+	}
+	if _, err := ResolveCategory("", "", nil); err == nil {
+		t.Error("empty name should error")
+	}
+}
+
+func TestList_BusinessTierIncludesCommunity(t *testing.T) {
+	// All shipped presets are community tier — business tier should see the
+	// same count (or more in the future).
+	c := List(func() Tier { return TierCommunity })
+	b := List(func() Tier { return TierBusiness })
+	if len(b) < len(c) {
+		t.Errorf("business should see >= community count (c=%d b=%d)", len(c), len(b))
+	}
+}
+
+func TestMergeLimits_FullSort(t *testing.T) {
+	entries := []config.LimitEntry{
+		{User: "b", Type: "hard", Item: "nofile", Value: "2"},
+		{User: "a", Type: "soft", Item: "nproc", Value: "1"},
+		{User: "a", Type: "hard", Item: "nofile", Value: "1"},
+		{User: "a", Type: "soft", Item: "nofile", Value: "1"},
+	}
+	out := MergeLimits(entries, nil)
+	if len(out) != 4 {
+		t.Fatalf("want 4, got %d", len(out))
+	}
+	// a/hard/nofile, a/soft/nofile, a/soft/nproc, b/hard/nofile
+	if out[0].User != "a" || out[0].Type != "hard" {
+		t.Errorf("bad order: %+v", out)
+	}
+	if out[3].User != "b" {
+		t.Errorf("bad order: %+v", out)
+	}
+}
+
 func containsStr(s []string, x string) bool {
 	for _, v := range s {
 		if v == x {

--- a/pkg/presets/registry.go
+++ b/pkg/presets/registry.go
@@ -1,0 +1,184 @@
+package presets
+
+import (
+	"fmt"
+	"sort"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+)
+
+// tierRank maps a Tier to a numeric precedence for comparison.
+func tierRank(t Tier) int {
+	switch t {
+	case TierCommunity:
+		return 1
+	case TierBusiness:
+		return 2
+	case TierEnterprise:
+		return 3
+	default:
+		return 1
+	}
+}
+
+// resolveTier returns the caller's active tier, defaulting to Community.
+func resolveTier(fn TierFunc) Tier {
+	if fn == nil {
+		return TierCommunity
+	}
+	t := fn()
+	if t == "" {
+		return TierCommunity
+	}
+	return t
+}
+
+// Resolve loads a preset by name. Returns an error if unknown or if the
+// caller's tier is below the preset's required tier.
+func Resolve(name string, tierFn TierFunc) (*Preset, error) {
+	if name == "" {
+		return nil, fmt.Errorf("preset: empty name")
+	}
+	idx, err := load()
+	if err != nil {
+		return nil, err
+	}
+	p, ok := idx.byName[name]
+	if !ok {
+		return nil, fmt.Errorf("preset %q not found", name)
+	}
+	caller := resolveTier(tierFn)
+	if tierRank(p.Metadata.Tier) > tierRank(caller) {
+		return nil, fmt.Errorf("preset %q requires tier %q (active tier: %q)", name, p.Metadata.Tier, caller)
+	}
+	return p, nil
+}
+
+// List returns metadata for all presets available at the caller's tier.
+// Results are sorted by (category, name) for stable output.
+func List(tierFn TierFunc) []PresetMeta {
+	idx, err := load()
+	if err != nil {
+		return nil
+	}
+	caller := resolveTier(tierFn)
+	out := make([]PresetMeta, 0, len(idx.meta))
+	for _, m := range idx.meta {
+		if tierRank(m.Tier) <= tierRank(caller) {
+			out = append(out, m)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Category != out[j].Category {
+			return out[i].Category < out[j].Category
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// BundleExpand resolves a bundle name and returns a map of category → child
+// preset name. The caller can then call Resolve(childName, ...) for each
+// category.
+func BundleExpand(name string, tierFn TierFunc) (map[string]string, error) {
+	p, err := Resolve(name, tierFn)
+	if err != nil {
+		return nil, err
+	}
+	if p.Kind != "Bundle" {
+		return nil, fmt.Errorf("preset %q is not a Bundle (kind=%q)", name, p.Kind)
+	}
+	idx, _ := load()
+	b, ok := idx.bundles[name]
+	if !ok {
+		return nil, fmt.Errorf("bundle %q: internal: not in bundle index", name)
+	}
+	out := map[string]string{}
+	if b.DirectoriesPreset != "" {
+		out["directories"] = b.DirectoriesPreset
+	}
+	if b.UsersGroupsPreset != "" {
+		out["users_groups"] = b.UsersGroupsPreset
+	}
+	if b.PackagesPreset != "" {
+		out["packages"] = b.PackagesPreset
+	}
+	if b.SysctlPreset != "" {
+		out["sysctl"] = b.SysctlPreset
+	}
+	if b.LimitsPreset != "" {
+		out["limits"] = b.LimitsPreset
+	}
+	return out, nil
+}
+
+// ---- Typed spec decoders ---------------------------------------------------
+//
+// These helpers decode a preset's RawSpec into the concrete Go types the
+// managers consume. They are thin wrappers over yaml.Marshal + Unmarshal so
+// the category-specific schema in YAML stays the authoritative format.
+
+// DirectoriesSpec returns the directories list from a directories preset.
+func DirectoriesSpec(p *Preset) ([]config.Directory, error) {
+	var shape struct {
+		Directories []config.Directory `yaml:"directories"`
+	}
+	if err := reencode(p.RawSpec, &shape); err != nil {
+		return nil, err
+	}
+	return shape.Directories, nil
+}
+
+// UsersGroupsSpec returns the users+groups block from a users_groups preset.
+func UsersGroupsSpec(p *Preset) (*config.UsersGroups, error) {
+	var shape struct {
+		UsersGroups config.UsersGroups `yaml:"users_groups"`
+	}
+	if err := reencode(p.RawSpec, &shape); err != nil {
+		return nil, err
+	}
+	return &shape.UsersGroups, nil
+}
+
+// PackagesSpec returns the packages block from a packages preset.
+func PackagesSpec(p *Preset) (*config.Packages, error) {
+	var shape struct {
+		Packages config.Packages `yaml:"packages"`
+	}
+	if err := reencode(p.RawSpec, &shape); err != nil {
+		return nil, err
+	}
+	return &shape.Packages, nil
+}
+
+// SysctlSpec returns the sysctl list from a sysctl preset.
+func SysctlSpec(p *Preset) ([]config.SysctlEntry, error) {
+	var shape struct {
+		Sysctl []config.SysctlEntry `yaml:"sysctl"`
+	}
+	if err := reencode(p.RawSpec, &shape); err != nil {
+		return nil, err
+	}
+	return shape.Sysctl, nil
+}
+
+// LimitsSpec returns the limits list from a limits preset.
+func LimitsSpec(p *Preset) ([]config.LimitEntry, error) {
+	var shape struct {
+		Limits []config.LimitEntry `yaml:"limits"`
+	}
+	if err := reencode(p.RawSpec, &shape); err != nil {
+		return nil, err
+	}
+	return shape.Limits, nil
+}
+
+func reencode(src any, dst any) error {
+	b, err := yaml.Marshal(src)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(b, dst)
+}

--- a/pkg/presets/registry.go
+++ b/pkg/presets/registry.go
@@ -35,8 +35,9 @@ func resolveTier(fn TierFunc) Tier {
 	return t
 }
 
-// Resolve loads a preset by name. Returns an error if unknown or if the
-// caller's tier is below the preset's required tier.
+// Resolve loads a preset by name. Returns an error if unknown, ambiguous
+// (same name in multiple categories), or if the caller's tier is below the
+// preset's required tier. For ambiguous names, use ResolveCategory.
 func Resolve(name string, tierFn TierFunc) (*Preset, error) {
 	if name == "" {
 		return nil, fmt.Errorf("preset: empty name")
@@ -45,13 +46,42 @@ func Resolve(name string, tierFn TierFunc) (*Preset, error) {
 	if err != nil {
 		return nil, err
 	}
-	p, ok := idx.byName[name]
-	if !ok {
+	matches, ok := idx.byName[name]
+	if !ok || len(matches) == 0 {
 		return nil, fmt.Errorf("preset %q not found", name)
 	}
+	if len(matches) > 1 {
+		cats := make([]string, 0, len(matches))
+		for _, m := range matches {
+			cats = append(cats, string(m.Metadata.Category))
+		}
+		return nil, fmt.Errorf("preset %q is ambiguous across categories %v; use ResolveCategory", name, cats)
+	}
+	p := matches[0]
 	caller := resolveTier(tierFn)
 	if tierRank(p.Metadata.Tier) > tierRank(caller) {
 		return nil, fmt.Errorf("preset %q requires tier %q (active tier: %q)", name, p.Metadata.Tier, caller)
+	}
+	return p, nil
+}
+
+// ResolveCategory loads a preset by (category, name). This is the form the
+// managers use, since each manager owns a single category.
+func ResolveCategory(category, name string, tierFn TierFunc) (*Preset, error) {
+	if name == "" {
+		return nil, fmt.Errorf("preset: empty name")
+	}
+	idx, err := load()
+	if err != nil {
+		return nil, err
+	}
+	p, ok := idx.byKey[catKey(category, name)]
+	if !ok {
+		return nil, fmt.Errorf("preset %s/%s not found", category, name)
+	}
+	caller := resolveTier(tierFn)
+	if tierRank(p.Metadata.Tier) > tierRank(caller) {
+		return nil, fmt.Errorf("preset %s/%s requires tier %q (active tier: %q)", category, name, p.Metadata.Tier, caller)
 	}
 	return p, nil
 }
@@ -80,10 +110,10 @@ func List(tierFn TierFunc) []PresetMeta {
 }
 
 // BundleExpand resolves a bundle name and returns a map of category → child
-// preset name. The caller can then call Resolve(childName, ...) for each
-// category.
+// preset name. The caller can then call ResolveCategory(category, childName,
+// ...) for each category.
 func BundleExpand(name string, tierFn TierFunc) (map[string]string, error) {
-	p, err := Resolve(name, tierFn)
+	p, err := ResolveCategory("bundles", name, tierFn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/presets/schema.go
+++ b/pkg/presets/schema.go
@@ -1,0 +1,61 @@
+// Package presets provides the embedded conventions library for linuxctl.
+//
+// Presets are shipped as YAML files under pkg/presets/data/ and embedded into
+// the linuxctl binary via go:embed. Each preset declares a named, reusable
+// fragment of desired state for one of five categories (directories,
+// users_groups, packages, sysctl, limits) plus a "Bundle" meta-preset that
+// composes one preset per category.
+//
+// Merge precedence (lowest → highest): bundle_preset < individual *_preset
+// fields < explicit entries in the stack's linux.yaml. See plan 033.
+package presets
+
+// Tier mirrors pkg/license.Tier without a circular import.
+type Tier string
+
+const (
+	// TierCommunity is the default / free tier. All shipped Phase-1 presets
+	// are at this tier.
+	TierCommunity Tier = "community"
+	// TierBusiness unlocks hardened-cis and other enterprise-leaning presets.
+	TierBusiness Tier = "business"
+	// TierEnterprise is the highest tier; reserved for future presets.
+	TierEnterprise Tier = "enterprise"
+)
+
+// APIVersion is the current preset schema identifier.
+const APIVersion = "linuxctl.itunified.io/preset/v1"
+
+// PresetMeta is the common metadata block on every preset + bundle.
+type PresetMeta struct {
+	Name     string `yaml:"name"`
+	Category string `yaml:"category"`
+	Tier     Tier   `yaml:"tier"`
+	Source   string `yaml:"source,omitempty"`
+	Version  string `yaml:"version,omitempty"`
+}
+
+// Preset is a single named fragment of desired state. The Spec field is
+// decoded category-specifically by the registry (the raw decoded YAML map
+// is retained in RawSpec for rendering / show commands).
+type Preset struct {
+	APIVersion string     `yaml:"apiVersion"`
+	Kind       string     `yaml:"kind"`
+	Metadata   PresetMeta `yaml:"metadata"`
+	// RawSpec holds the unparsed spec map — category-specific typed views
+	// are decoded on demand by the registry helpers.
+	RawSpec map[string]any `yaml:"spec"`
+}
+
+// Bundle is a meta-preset that composes one preset per category.
+type Bundle struct {
+	DirectoriesPreset string `yaml:"directories_preset,omitempty"`
+	UsersGroupsPreset string `yaml:"users_groups_preset,omitempty"`
+	PackagesPreset    string `yaml:"packages_preset,omitempty"`
+	SysctlPreset      string `yaml:"sysctl_preset,omitempty"`
+	LimitsPreset      string `yaml:"limits_preset,omitempty"`
+}
+
+// TierFunc is a callback supplied by the caller (usually wired to the license
+// gate) that reports the user's active tier. Passing nil defaults to Community.
+type TierFunc func() Tier


### PR DESCRIPTION
## Summary

Implements the conventions library (plan 033, closes #19). The linuxctl binary now ships 19 embedded YAML presets across 6 categories, with CLI discovery + bundle composition + automatic merge into linux.yaml manifests.

### What ships

- **pkg/presets/** — embedded preset engine (go:embed YAML, sync.Once lazy parse)
- **19 preset YAML files** under pkg/presets/data/ (directories, users_groups, packages, sysctl, limits, bundles)
- **4 new Linux config fields**: `directories_preset`, `users_groups_preset`, `packages_preset`, `bundle_preset` (all optional, additive — no breaking changes)
- **linuxctl preset list / show / show --expand** discovery CLI
- **linuxctl config render** now implemented (was stub) — expands bundle + presets + redacts ${vault:...}/${gen:...}
- **Regression-gate**: hardcoded `oracle-19c` sysctl + limits data migrated byte-for-byte to YAML; existing test suites remain green

### Architecture notes

- Registry keys by (category, name) — `oracle-19c` + `pg-16` are legitimately reused across categories
- Bundle expansion happens at `config.LoadLinux` time via a `BundleExpander` hook registered by `pkg/presets.init` (avoids a pkg/config ↔ pkg/presets cycle)
- Explicit manifest entries always win over per-category presets, which always win over bundle expansion
- All merge functions produce deterministic (sorted) output

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all green (87 tests)
- [x] `go vet ./...` — clean
- [x] `staticcheck ./...` — clean
- [x] Coverage: pkg/config 96.4%, pkg/managers 93.3%, pkg/presets 87.4% (error branches in lazy-load init code acceptable)
- [x] Smoke: `linuxctl preset list --category bundles` prints 5 bundles
- [x] Smoke: `linuxctl preset show oracle-rac-19c --expand` resolves all 5 child presets
- [x] Smoke: `linuxctl config render <bundle-using-yaml>` outputs fully-expanded Linux YAML

## Migration

Follow-up PR in `itunified-io/infrastructure` will migrate `stacks/clext5/os/linux.yaml` to `bundle_preset: oracle-rac-19c`, dropping ~60 lines of boilerplate. That migration will be verified against this branch (Phase 5 of plan 033) before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)