### PR TITLE
fix: orchestrator passes *config.Linux to PackageManager (#21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to `linuxctl` are documented in this file. The format follow
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the project uses
 CalVer (`vYYYY.MM.DD.TS`).
 
+## v2026.04.30.1 — 2026-04-30
+
+### fix: orchestrator passes *config.Linux to PackageManager (#21)
+
+`pkg/apply/orchestrator.go:desiredFor` returned `o.Linux.Packages` (raw
+`*config.Packages`) for the `package` manager. `PackageManager.castPackages`
+only handled `*config.Linux` / `PackagesSpec`; passing `*config.Packages`
+was rejected with `package: unsupported desired-state type *config.Packages`,
+AND skipped `bundle_preset` expansion.
+
+Fix:
+- Orchestrator now passes the full `*config.Linux` for the `package` case,
+  matching `internal/root/runtime.go`'s already-correct path. Bundle presets
+  (`oracle-single-19c`, etc.) now expand into the install/remove lists.
+- `castPackages` defensively accepts `*config.Packages` / `config.Packages`
+  too, returning `PackagesSpec{Install, Remove}` directly. Bundle presets
+  cannot be expanded on this fallback path (no enclosing `*config.Linux`).
+- Updated `pkg/apply/coverage_test.go` to assert the new behavior.
+
+Live-caught running `/lab-up` Phase C against ext3+ext4 (infrastructure
+plan 034) — VMs install + boot fine on static IPs, blocked at OS-config
+layer until this fix.
+
 ## v2026.04.11.9 — 2026-04-22
 
 ### Added — Conventions library (plan 033, #19)

--- a/pkg/apply/coverage_test.go
+++ b/pkg/apply/coverage_test.go
@@ -80,9 +80,10 @@ func TestOrchestrator_DesiredFor_AllManagerNames(t *testing.T) {
 	if got, ok := stubs[3].got.([]config.Directory); !ok || len(got) != 1 {
 		t.Errorf("dir spec mismatch: %T", stubs[3].got)
 	}
-	// package → Packages
-	if stubs[4].got != l.Packages {
-		t.Errorf("package spec mismatch")
+	// package → full Linux (so bundle_preset can be expanded by
+	// PackageManager.castPackages → packagesFromLinux). Fixes linuxctl#21.
+	if stubs[4].got != l {
+		t.Errorf("package spec mismatch: want full *Linux for bundle_preset, got %T", stubs[4].got)
 	}
 	// sysctl → full Linux (default branch)
 	if stubs[5].got != l {

--- a/pkg/apply/orchestrator.go
+++ b/pkg/apply/orchestrator.go
@@ -147,7 +147,12 @@ func (o *Orchestrator) desiredFor(name string) managers.Spec {
 	case "dir":
 		return o.Linux.Directories
 	case "package":
-		return o.Linux.Packages
+		// Pass the full Linux spec so PackageManager.castPackages can
+		// expand the bundle_preset (oracle-single-19c, etc.). Returning
+		// the raw *config.Packages bypasses preset expansion AND is
+		// rejected by castPackages with "unsupported desired-state type"
+		// (linuxctl#21).
+		return o.Linux
 	}
 	// For other managers, pass the full Linux spec — each may ignore.
 	return o.Linux

--- a/pkg/managers/package.go
+++ b/pkg/managers/package.go
@@ -391,6 +391,17 @@ func castPackages(desired Spec) (PackagesSpec, error) {
 		return packagesFromLinux(v), nil
 	case config.Linux:
 		return packagesFromLinux(&v), nil
+	case *config.Packages:
+		// Raw config.Packages (no bundle preset context). Convert
+		// install/remove lists directly. This is the fallback path when
+		// a caller passes the typed config struct without the enclosing
+		// Linux — bundle presets cannot be expanded here.
+		if v == nil {
+			return PackagesSpec{}, nil
+		}
+		return PackagesSpec{Install: v.Install, Remove: v.Remove}, nil
+	case config.Packages:
+		return PackagesSpec{Install: v.Install, Remove: v.Remove}, nil
 	case nil:
 		return PackagesSpec{}, nil
 	default:


### PR DESCRIPTION
Closes #21. Live-caught running /lab-up Phase C for ext3+ext4 in infrastructure plan 034.