### PR TITLE
feat(presets): dbx-host bundle (#44)

### DIFF
--- a/pkg/presets/data/bundles/dbx-host.yaml
+++ b/pkg/presets/data/bundles/dbx-host.yaml
@@ -1,0 +1,27 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: dbx-host
+  category: bundles
+  tier: community
+  source: |
+    dbx-control host: long-lived service host running the agentic-AI
+    control plane (dbx-daemon + dbx-admin UI + OTEL stack
+    (Tempo + Grafana + collector) + labctl ledger + litestream
+    replication + cloudflared + vault-agent).
+
+    Used by infrastructure/stacks/dbx-control/linux.yaml. Operationally
+    deployed on dbx01.itunified.io (10.10.0.40, proximo VM 2900).
+    Replaces operator-workstation colocation of these services.
+
+    Per ADR-0109 of itunified-io/infrastructure (agentic-AI hardening
+    master plan Item 11 — Wave C operational capstone). Companion plan
+    at infrastructure/docs/plans/036-dbx-control-deployment.md.
+  version: "2026-04-30"
+spec:
+  bundle:
+    directories_preset: dbx-host
+    users_groups_preset: dbx-host
+    packages_preset: dbx-host
+    sysctl_preset: dbx-host
+    limits_preset: dbx-host

--- a/pkg/presets/data/directories/dbx-host.yaml
+++ b/pkg/presets/data/directories/dbx-host.yaml
@@ -1,0 +1,28 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: dbx-host
+  category: directories
+  tier: community
+  source: |
+    dbx-host directory layout. /var/lib/dbx is the data root (mounted on
+    a dedicated xfs LV per linux.yaml lvm.logical_volumes). UIDs match
+    container expectations:
+      - dbx (60001):    audit, state, ledger
+      - tempo (10001):  /var/lib/dbx/tempo
+      - grafana (472):  /var/lib/dbx/grafana
+    /etc/dbx holds vault-agent rendered env files + docker-compose.yml.
+    Per ADR-0109 of itunified-io/infrastructure.
+  version: "2026-04-30"
+spec:
+  directories:
+    - { path: "/var/lib/dbx",         owner: "dbx",   group: "dbx",   mode: "0750" }
+    - { path: "/var/lib/dbx/audit",   owner: "dbx",   group: "dbx",   mode: "0750" }
+    - { path: "/var/lib/dbx/state",   owner: "dbx",   group: "dbx",   mode: "0750" }
+    - { path: "/var/lib/dbx/ledger",  owner: "dbx",   group: "dbx",   mode: "0750" }
+    - { path: "/var/lib/dbx/tempo",   owner: "10001", group: "10001", mode: "0750" }
+    - { path: "/var/lib/dbx/grafana", owner: "472",   group: "472",   mode: "0750" }
+    - { path: "/etc/dbx",             owner: "root",  group: "dbx",   mode: "0750" }
+    - { path: "/etc/dbx/templates",   owner: "root",  group: "dbx",   mode: "0750" }
+    # NAS mount target (created idempotently; mount itself is in linux.yaml mounts:)
+    - { path: "/smb/dbx-backup",      owner: "dbx",   group: "dbx",   mode: "0750" }

--- a/pkg/presets/data/limits/dbx-host.yaml
+++ b/pkg/presets/data/limits/dbx-host.yaml
@@ -1,0 +1,21 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: dbx-host
+  category: limits
+  tier: community
+  source: |
+    dbx-host ulimits. The dbx user runs container processes (dbx-daemon
+    + labctl-ledger via Docker user mapping); raised nofile + nproc match
+    Tempo + Grafana defaults. memlock=unlimited preserves litestream's
+    ability to mmap WAL files without page-cache thrash.
+    Per ADR-0109 of itunified-io/infrastructure.
+  version: "2026-04-30"
+spec:
+  limits:
+    - { user: "dbx", type: "soft", item: "nofile",  value: "65536" }
+    - { user: "dbx", type: "hard", item: "nofile",  value: "131072" }
+    - { user: "dbx", type: "soft", item: "nproc",   value: "16384" }
+    - { user: "dbx", type: "hard", item: "nproc",   value: "32768" }
+    - { user: "dbx", type: "soft", item: "memlock", value: "unlimited" }
+    - { user: "dbx", type: "hard", item: "memlock", value: "unlimited" }

--- a/pkg/presets/data/packages/dbx-host.yaml
+++ b/pkg/presets/data/packages/dbx-host.yaml
@@ -1,0 +1,41 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: dbx-host
+  category: packages
+  tier: community
+  source: |
+    dbx-control host packages: Docker + docker-compose-plugin for the
+    container stack (dbx-daemon, OTEL collector, Tempo, Grafana, labctl,
+    litestream, cloudflared); HashiCorp Vault for vault-agent template
+    rendering; chrony + firewalld for baseline; cifs-utils for NAS mount
+    of //nas/dbx-backup; rsync for nightly audit chain mirror; jq + curl
+    + tar + xfsprogs for ops; policycoreutils-python-utils for SELinux.
+    Per ADR-0109 of itunified-io/infrastructure (agentic-AI hardening
+    Item 11 capstone).
+  version: "2026-04-30"
+spec:
+  packages:
+    install:
+      # Container runtime
+      - docker-ce
+      - docker-ce-cli
+      - containerd.io
+      - docker-compose-plugin
+      # Vault agent (renders /etc/dbx/*.env from Vault AppRole)
+      - vault
+      # Time + firewall baseline
+      - chrony
+      - firewalld
+      # NAS mount + backup
+      - cifs-utils
+      - rsync
+      # Ops + ledger replication
+      - litestream
+      - jq
+      - curl
+      - tar
+      - xfsprogs
+      # SELinux helpers
+      - policycoreutils-python-utils
+      - container-selinux

--- a/pkg/presets/data/sysctl/dbx-host.yaml
+++ b/pkg/presets/data/sysctl/dbx-host.yaml
@@ -1,0 +1,30 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: dbx-host
+  category: sysctl
+  tier: community
+  source: |
+    dbx-host kernel tunables. vm.max_map_count is bumped from 65530
+    (default) to 262144 — required by Tempo (grafana/tempo:2.6.0) for
+    block-storage memory mappings; equivalent to Elasticsearch's
+    canonical recommendation. Other values harden the host for the
+    OTEL ingest pipeline (high-fanout TCP from collector + Grafana
+    dashboards) and inotify-heavy Docker volume operations.
+    Per ADR-0109 of itunified-io/infrastructure.
+  version: "2026-04-30"
+spec:
+  sysctl:
+    # Tempo block-storage requires bumped mmap count (canonical 262144 — same
+    # as Elasticsearch). Default 65530 causes Tempo to crash with
+    # "max virtual memory areas vm.max_map_count is too low".
+    - { key: "vm.max_map_count", value: "262144" }
+    # OTEL collector accepts many short-lived TCP connections from
+    # post-tool-use hooks across operator workstations + future fleet.
+    - { key: "net.core.somaxconn", value: "4096" }
+    # Docker bind-mounts + Grafana/Tempo file watches benefit from a
+    # larger inotify ceiling.
+    - { key: "fs.inotify.max_user_watches", value: "524288" }
+    # Conservative IPv4 forwarding off (host is not a router; tunnel
+    # egress goes through cloudflared in host-network mode).
+    - { key: "net.ipv4.ip_forward", value: "0" }

--- a/pkg/presets/data/users_groups/dbx-host.yaml
+++ b/pkg/presets/data/users_groups/dbx-host.yaml
@@ -1,0 +1,25 @@
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Preset
+metadata:
+  name: dbx-host
+  category: users_groups
+  tier: community
+  source: |
+    dbx-host user/group baseline. The 'dbx' system user owns
+    /var/lib/dbx (audit chain, ledger, state). UID/GID pinned at 60001
+    so volume mounts in the docker-compose stack stay deterministic
+    across hosts (see docker/dbx-control/docker-compose.yml).
+    Per ADR-0109 of itunified-io/infrastructure.
+  version: "2026-04-30"
+spec:
+  users_groups:
+    groups:
+      - { name: "dbx", gid: 60001 }
+    users:
+      # System user; no shell. Container processes inside dbx-daemon /
+      # labctl-ledger run as this UID via Docker user mapping. Home is
+      # /var/lib/dbx so the data partition (xfs on dbx_vg/data) is
+      # automatically owned correctly post-mkfs.
+      - { name: "dbx", uid: 60001, gid: "dbx",
+          home: "/var/lib/dbx", shell: "/sbin/nologin",
+          groups: [] }


### PR DESCRIPTION
Wave C Item 11 capstone — Cluster A item 1. Adds 5 sub-presets + 1 bundle for dbx-control hosts. Per ADR-0109 of itunified-io/infrastructure. Closes #44.