### PR TITLE
feat(config): accept proxctl-style hosts map in linux.yaml (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,34 @@
 # Changelog
+## v2026.05.01.1 — 2026-05-01
+
+### feat(config): accept proxctl-style hosts map in linux.yaml (#48)
+
+`hosts:` in linux.yaml now accepts both shapes:
+
+1. **Legacy selector array** (existing): `hosts: [{selector: {role: [db]}, spec: {...}}]` → populates `Linux.Hosts []HostSpec`
+2. **proxctl-style map** (NEW): `hosts: {dbx01: {packages: {install: [...]}}}` → populates `Linux.HostsByName map[string]Spec`
+
+Custom `Linux.UnmarshalYAML` dispatches on the YAML node kind (sequence vs
+mapping) and decodes into the appropriate field. Both fields are
+consulted at runtime; only one is non-empty for a given manifest.
+
+New `Linux.EffectiveSpec(hostname)` helper resolves the spec for a given
+`--host` flag value: when the hostname matches a `HostsByName` key, the
+host's spec is layered over top-level Linux fields (host wins); otherwise
+top-level Linux is returned as-is. Slices and pointers replace rather than
+merge — explicit operator override semantics.
+
+Operators authoring stacks in the proxctl env.yaml convention (
+`hosts: <hostname>: {...}` mirroring `spec.hypervisor.nodes`) can now
+share that file shape between proxctl + linuxctl with no rewrite.
+
+8 new unit tests; full test suite green (no regression).
+
+Closes #48. Capstone follow-up #1 from infrastructure ADR-0109. Note: the
+proxctl manifest schema also includes fields not yet on linuxctl Spec
+(timezone, keymap, hostname, packages.present alias, services.enabled
+list shape) — full schema reconciliation tracked separately.
+
 ## v2026.04.30.11 — 2026-04-30
 
 ### feat: dbx-host bundle preset (#44)

--- a/pkg/config/hosts_map_test.go
+++ b/pkg/config/hosts_map_test.go
@@ -1,0 +1,157 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestLoadLinux_HostsAsSequence — regression: existing []HostSpec form must
+// continue to parse cleanly into Linux.Hosts (not Linux.HostsByName).
+func TestLoadLinux_HostsAsSequence(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(`kind: Linux
+hosts:
+  - selector:
+      role: [db]
+    spec:
+      packages:
+        install: [chrony]
+`), 0o644))
+	l, err := LoadLinux(p)
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	assert.Len(t, l.Hosts, 1)
+	assert.Equal(t, []string{"db"}, l.Hosts[0].Selector.Role)
+	assert.Empty(t, l.HostsByName, "map field must be empty when sequence form is used")
+}
+
+// TestLoadLinux_HostsAsMap — proxctl-style: `hosts: <name>: {...}`. New form;
+// canonical for stacks authored against the proxctl env.yaml convention
+// (matches spec.hypervisor.nodes shape).
+func TestLoadLinux_HostsAsMap(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(`kind: Linux
+bundle_preset: dbx-host-ubuntu
+hosts:
+  dbx01:
+    packages:
+      install: [docker-ce, chrony, qemu-guest-agent]
+    services:
+      - name: docker
+        enabled: true
+        state: running
+    sysctl:
+      - key: vm.max_map_count
+        value: "262144"
+`), 0o644))
+	l, err := LoadLinux(p)
+	require.NoError(t, err)
+	require.NotNil(t, l)
+	assert.Empty(t, l.Hosts, "sequence field must be empty when map form is used")
+	require.Contains(t, l.HostsByName, "dbx01")
+
+	dbx01 := l.HostsByName["dbx01"]
+	require.NotNil(t, dbx01.Packages)
+	assert.Contains(t, dbx01.Packages.Install, "docker-ce")
+	assert.Len(t, dbx01.Services, 1)
+	assert.Equal(t, "docker", dbx01.Services[0].Name)
+	require.Len(t, dbx01.Sysctl, 1)
+	assert.Equal(t, "vm.max_map_count", dbx01.Sysctl[0].Key)
+}
+
+// TestLoadLinux_HostsAsMap_MultipleHosts — map form with multiple hostnames
+// (typical 2-node cluster manifest).
+func TestLoadLinux_HostsAsMap_MultipleHosts(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(`kind: Linux
+hosts:
+  ext3adm1:
+    packages: { install: [chrony] }
+  ext4adm1:
+    packages: { install: [chrony, openssh-server] }
+`), 0o644))
+	l, err := LoadLinux(p)
+	require.NoError(t, err)
+	require.Len(t, l.HostsByName, 2)
+	got := []string{}
+	for k := range l.HostsByName {
+		got = append(got, k)
+	}
+	assert.ElementsMatch(t, []string{"ext3adm1", "ext4adm1"}, got)
+	assert.Len(t, l.HostsByName["ext4adm1"].Packages.Install, 2)
+}
+
+// TestEffectiveSpec_HostInMap — when --host matches a HostsByName key, the
+// effective spec is the host's spec layered over top-level Linux fields.
+func TestEffectiveSpec_HostInMap(t *testing.T) {
+	l := &Linux{
+		BundlePreset: "dbx-host-ubuntu", // top-level
+		HostsByName: map[string]Spec{
+			"dbx01": {
+				Packages: &Packages{Install: []string{"docker-ce"}},
+			},
+		},
+	}
+	eff := l.EffectiveSpec("dbx01")
+	require.NotNil(t, eff)
+	require.NotNil(t, eff.Packages)
+	assert.Contains(t, eff.Packages.Install, "docker-ce")
+	assert.Equal(t, "dbx-host-ubuntu", eff.BundlePreset, "top-level fields propagate when not overridden")
+}
+
+// TestEffectiveSpec_HostNotInMap — when --host doesn't match any key, fall
+// back to top-level Linux as the effective spec.
+func TestEffectiveSpec_HostNotInMap(t *testing.T) {
+	l := &Linux{
+		Packages: &Packages{Install: []string{"chrony"}},
+	}
+	eff := l.EffectiveSpec("anyhost")
+	require.NotNil(t, eff)
+	require.NotNil(t, eff.Packages)
+	assert.Equal(t, []string{"chrony"}, eff.Packages.Install)
+}
+
+// TestEffectiveSpec_TopLevelMergeOverlay — host-specific fields override
+// top-level when both are set. Top-level fields not set in host carry through.
+func TestEffectiveSpec_TopLevelMergeOverlay(t *testing.T) {
+	l := &Linux{
+		BundlePreset: "shared-bundle",                          // top-level
+		Packages:     &Packages{Install: []string{"top-only"}}, // top-level
+		HostsByName: map[string]Spec{
+			"web01": {
+				Packages: &Packages{Install: []string{"host-only"}}, // override
+			},
+		},
+	}
+	eff := l.EffectiveSpec("web01")
+	require.NotNil(t, eff)
+	assert.Equal(t, "shared-bundle", eff.BundlePreset, "top-level scalars carry through when host doesn't override")
+	require.NotNil(t, eff.Packages)
+	assert.Equal(t, []string{"host-only"}, eff.Packages.Install, "host overrides top-level slice (no merge)")
+}
+
+// TestEffectiveSpec_NilLinux — defensive: nil receiver returns nil.
+func TestEffectiveSpec_NilLinux(t *testing.T) {
+	var l *Linux
+	assert.Nil(t, l.EffectiveSpec("any"))
+}
+
+// TestLoadLinux_HostsRejectsUnknownNodeKind — robustness: a `hosts:` value
+// that's neither sequence nor mapping should fail with a clear error.
+func TestLoadLinux_HostsRejectsUnknownNodeKind(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	require.NoError(t, os.WriteFile(p, []byte(`kind: Linux
+hosts: "this is a string"
+`), 0o644))
+	_, err := LoadLinux(p)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hosts")
+}

--- a/pkg/config/hosts_shape.go
+++ b/pkg/config/hosts_shape.go
@@ -1,0 +1,169 @@
+package config
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// linuxYAML is a private alias used solely to defeat the recursive
+// UnmarshalYAML lookup; without it, yaml.Node.Decode(&Linux{}) would
+// re-enter Linux.UnmarshalYAML and stack-overflow.
+type linuxYAML Linux
+
+// UnmarshalYAML implements custom decoding so the `hosts:` key accepts both
+// the legacy `[]HostSpec` (selector array) and the proxctl-style
+// `map[string]Spec` (hostname-keyed map). See issue #48 + linuxctl#48 for
+// rationale.
+func (l *Linux) UnmarshalYAML(node *yaml.Node) error {
+	// Decode all non-`hosts` fields via the alias (which has no UnmarshalYAML
+	// defined). We strip `hosts:` from the node tree first.
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("linux.yaml root must be a mapping (got kind %d)", node.Kind)
+	}
+
+	// Walk the mapping, separating `hosts:` from everything else.
+	var hostsNode *yaml.Node
+	rest := &yaml.Node{Kind: yaml.MappingNode, Tag: node.Tag}
+	for i := 0; i < len(node.Content); i += 2 {
+		key, val := node.Content[i], node.Content[i+1]
+		if key.Value == "hosts" {
+			hostsNode = val
+			continue
+		}
+		rest.Content = append(rest.Content, key, val)
+	}
+
+	// Decode the rest of the manifest via the alias type (no custom unmarshal).
+	var inner linuxYAML
+	if err := rest.Decode(&inner); err != nil {
+		return fmt.Errorf("decode linux.yaml: %w", err)
+	}
+	*l = Linux(inner)
+
+	// Now dispatch on hosts: shape.
+	if hostsNode == nil {
+		return nil
+	}
+	switch hostsNode.Kind {
+	case yaml.SequenceNode:
+		var legacy []HostSpec
+		if err := hostsNode.Decode(&legacy); err != nil {
+			return fmt.Errorf("decode hosts (sequence form): %w", err)
+		}
+		l.Hosts = legacy
+	case yaml.MappingNode:
+		byName := map[string]Spec{}
+		// Walk pairs manually so we get hostname keys and decode each value
+		// as a Spec (which is alias for Linux — but Linux has UnmarshalYAML,
+		// so use the alias to avoid recursion).
+		for i := 0; i < len(hostsNode.Content); i += 2 {
+			k, v := hostsNode.Content[i], hostsNode.Content[i+1]
+			if k.Kind != yaml.ScalarNode {
+				return fmt.Errorf("hosts map key must be a scalar hostname (got kind %d)", k.Kind)
+			}
+			var s linuxYAML
+			if err := v.Decode(&s); err != nil {
+				return fmt.Errorf("decode hosts[%q]: %w", k.Value, err)
+			}
+			byName[k.Value] = Spec(s)
+		}
+		l.HostsByName = byName
+	default:
+		return fmt.Errorf("hosts: must be a sequence (selector form) or mapping (proxctl-style); got kind %d", hostsNode.Kind)
+	}
+	return nil
+}
+
+// EffectiveSpec returns the resolved Spec for a given hostname. When
+// `HostsByName` contains an entry for the hostname, the host's spec is
+// layered over the top-level Linux fields (host wins on overlap). When
+// no host-specific entry exists, the top-level Linux is returned as-is.
+//
+// On a nil receiver, returns nil. On an empty hostname or empty map,
+// returns the top-level Linux unchanged.
+func (l *Linux) EffectiveSpec(hostname string) *Spec {
+	if l == nil {
+		return nil
+	}
+	host, ok := l.HostsByName[hostname]
+	if !ok {
+		// No host-specific entry — return top-level Linux as the spec.
+		out := Spec(*l)
+		return &out
+	}
+	// Layer host on top of top-level. Start from a copy of the top-level
+	// Linux, then overwrite with non-zero host fields.
+	merged := Spec(*l)
+	overlaySpecOnto(&merged, &host)
+	return &merged
+}
+
+// overlaySpecOnto applies `src` non-zero fields onto `dst` in place. Slices
+// and pointers from `src` REPLACE `dst` values rather than merging — this
+// matches operator expectation for explicit per-host overrides (no
+// surprise concatenation).
+func overlaySpecOnto(dst *Spec, src *Spec) {
+	if src.Kind != "" {
+		dst.Kind = src.Kind
+	}
+	if src.APIVersion != "" {
+		dst.APIVersion = src.APIVersion
+	}
+	if src.DiskLayout != nil {
+		dst.DiskLayout = src.DiskLayout
+	}
+	if src.UsersGroups != nil {
+		dst.UsersGroups = src.UsersGroups
+	}
+	if len(src.Directories) > 0 {
+		dst.Directories = src.Directories
+	}
+	if len(src.Mounts) > 0 {
+		dst.Mounts = src.Mounts
+	}
+	if src.Packages != nil {
+		dst.Packages = src.Packages
+	}
+	if len(src.Sysctl) > 0 {
+		dst.Sysctl = src.Sysctl
+	}
+	if src.SysctlPreset != "" {
+		dst.SysctlPreset = src.SysctlPreset
+	}
+	if len(src.Limits) > 0 {
+		dst.Limits = src.Limits
+	}
+	if src.LimitsPreset != "" {
+		dst.LimitsPreset = src.LimitsPreset
+	}
+	if src.DirectoriesPreset != "" {
+		dst.DirectoriesPreset = src.DirectoriesPreset
+	}
+	if src.UsersGroupsPreset != "" {
+		dst.UsersGroupsPreset = src.UsersGroupsPreset
+	}
+	if src.PackagesPreset != "" {
+		dst.PackagesPreset = src.PackagesPreset
+	}
+	if src.BundlePreset != "" {
+		dst.BundlePreset = src.BundlePreset
+	}
+	if src.Firewall != nil {
+		dst.Firewall = src.Firewall
+	}
+	if len(src.HostsEntries) > 0 {
+		dst.HostsEntries = src.HostsEntries
+	}
+	if len(src.Services) > 0 {
+		dst.Services = src.Services
+	}
+	if src.SSHConfig != nil {
+		dst.SSHConfig = src.SSHConfig
+	}
+	if src.SELinux != nil {
+		dst.SELinux = src.SELinux
+	}
+	// HostsByName + Hosts are intentionally NOT carried through — those are
+	// manifest-shape concerns, not per-host spec data.
+}

--- a/pkg/config/linux.go
+++ b/pkg/config/linux.go
@@ -2,10 +2,28 @@ package config
 
 // Linux is the top-level linux.yaml manifest — the typed Linux layer consumed
 // by the 13 managers.
+//
+// `hosts:` accepts two shapes via custom UnmarshalYAML (issue #48):
+//
+//  1. Legacy selector array — populates `Hosts []HostSpec`:
+//     hosts:
+//       - selector: { role: [db] }
+//         spec: { packages: { install: [chrony] } }
+//
+//  2. proxctl-style map keyed by hostname — populates `HostsByName`:
+//     hosts:
+//       dbx01:
+//         packages: { install: [docker-ce, chrony] }
+//
+// `EffectiveSpec(hostname)` returns the resolved Spec for a given host:
+// when the hostname matches a `HostsByName` key, the host's spec is
+// layered over the top-level Linux fields; otherwise top-level Linux
+// is returned as-is.
 type Linux struct {
 	Kind         string         `yaml:"kind" validate:"required,eq=Linux"`
 	APIVersion   string         `yaml:"apiVersion,omitempty"`
-	Hosts        []HostSpec     `yaml:"hosts,omitempty"`
+	Hosts        []HostSpec     `yaml:"-"` // populated via custom UnmarshalYAML
+	HostsByName  map[string]Spec `yaml:"-"` // populated via custom UnmarshalYAML (proxctl-style)
 	DiskLayout   *DiskLayout    `yaml:"disk_layout,omitempty"`
 	UsersGroups  *UsersGroups   `yaml:"users_groups,omitempty"`
 	Directories  []Directory    `yaml:"directories,omitempty" validate:"dive"`


### PR DESCRIPTION
Closes #48 (capstone F/U #1). Adds custom Linux.UnmarshalYAML for dual-shape hosts: + EffectiveSpec helper. 8 new tests, full suite green.