### PR TITLE
fix(lab-up): Phase C blockers — hosts/firewall managers + disk idempotency + oracle-single-19c grid user (#51 #52 #53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,51 @@
 # Changelog
+## v2026.05.03.1 — 2026-05-03
+
+### fix(lab-up): Phase C blockers — hosts/firewall CLI + disk idempotency + oracle-single grid user (#51 #52 #53)
+
+Three blockers surfaced during /lab-up Phase C live execution against the
+ext3+ext4 lab. All three affected `linuxctl stack apply` and adjacent paths.
+
+**#51 — `linuxctl hosts apply` + `linuxctl firewall apply` were CLI stubs.**
+The HostsManager + FirewallManager are fully implemented in `pkg/managers/`,
+but `internal/root/hosts.go` and `internal/root/firewall.go` returned
+`Error: <subsystem> apply: not implemented`. As a result, stack manifests'
+`hosts_entries:` and `firewall.zones.public.ports:` blocks were silently
+dropped. Both CLI commands now wire to the shared `runManager` helper
+(matching disk/mount/user/package). `internal/root/runtime.go` `bindSession`
++ `desiredFor` extended to cover all 13 managers (previously only handled
+disk + mount).
+
+**#52 — `disk apply` was not idempotent over an existing matching FS.**
+Plan unconditionally emitted `mkfs.<fs> -F /dev/<vg>/<lv>` for every LV in
+the manifest, even when the LV already held a filesystem of the requested
+type. Re-running `apply apply` mid-flight halted the chain. Fix: discovery
+now probes `blkid -o value -s TYPE` on each LV; Plan skips mkfs when the
+existing filesystem matches; errors with an explicit remediation when the
+existing filesystem is a different type; falls through to mkfs when no
+filesystem is present. Adds `--reformat-filesystems` global flag for
+explicit destructive opt-in.
+
+**#53 — `oracle-single` users_groups preset GIDs misaligned with Oracle 19c
+defaults.** The preset already shipped with both `oracle` + `grid` users,
+but ASM group GIDs were 54323/54324/54325 instead of Oracle's documented
+defaults 54327/54328/54329. The preset also omitted Oracle's role-separation
+groups (`oper`, `backupdba`, `dgdba`, `kmdba`) and `oracle` was missing
+membership in `oper`. Updated to match
+https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/about-oracle-installation-user-accounts.html
+exactly. `oracle` user is now in `[dba, oper, backupdba, dgdba, kmdba, asmdba]`;
+`grid` user remains in `[asmadmin, asmdba, asmoper, dba]`. Privilege
+boundary between DB + GI homes preserved.
+
+Test additions: 4 new disk manager idempotency tests
+(skip-on-match, error-on-mismatch, mkfs-when-no-FS, --reformat-filesystems
+override); 3 new CLI wiring tests (hosts wired, firewall wired,
+--reformat-filesystems flag exposed); 1 new oracle-single regression gate.
+Existing `TestStubSubsystems_AllReturnNotImplemented` updated — firewall +
+hosts removed from the stub list.
+
+Closes #51, #52, #53.
+
 ## v2026.05.01.1 — 2026-05-01
 
 ### feat(config): accept proxctl-style hosts map in linux.yaml (#48)

--- a/internal/root/apply.go
+++ b/internal/root/apply.go
@@ -50,6 +50,7 @@ func runApply(action mgrAction) func(*cobra.Command, []string) error {
 		defer sess.Close()
 
 		orch := apply.New(nil, sess, gf.dryRun).WithLinux(linux)
+		orch.ReformatFilesystems = gf.reformatFilesystems
 
 		ctx, cancel := deadlineCtx()
 		defer cancel()

--- a/internal/root/firewall.go
+++ b/internal/root/firewall.go
@@ -1,30 +1,32 @@
 package root
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
+// newFirewallCmd wires the firewall subsystem CLI to the registered
+// FirewallManager via the shared runManager helper. Reads `firewall:` from
+// linux.yaml; reconciles ports + sources per zone (firewalld / ufw / nftables).
+// linuxctl#51 — Phase C blocker for /lab-up.
 func newFirewallCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "firewall",
-		Short: "Manage firewall state (plan / apply / verify)",
+		Use:   "firewall [env.yaml|linux.yaml]",
+		Short: "Manage host firewall state (plan / apply / verify)",
 	}
 	cmd.AddCommand(&cobra.Command{
-		Use:   "plan",
+		Use:   "plan [env.yaml|linux.yaml]",
 		Short: "Preview firewall changes against the desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("firewall plan: not implemented") },
+		RunE:  runManager("firewall", actionPlan),
 	})
 	cmd.AddCommand(&cobra.Command{
-		Use:   "apply",
-		Short: "Apply firewall changes to reach the desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("firewall apply: not implemented") },
+		Use:   "apply [env.yaml|linux.yaml]",
+		Short: "Apply firewall changes (idempotent: only adds missing ports/sources)",
+		RunE:  runManager("firewall", actionApply),
 	})
 	cmd.AddCommand(&cobra.Command{
-		Use:   "verify",
-		Short: "Verify observed firewall state matches desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("firewall verify: not implemented") },
+		Use:   "verify [env.yaml|linux.yaml]",
+		Short: "Verify observed firewall ports/sources match desired state",
+		RunE:  runManager("firewall", actionVerify),
 	})
 	return cmd
 }

--- a/internal/root/hosts.go
+++ b/internal/root/hosts.go
@@ -1,30 +1,32 @@
 package root
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
+// newHostsCmd wires the hosts subsystem CLI to the registered HostsManager via
+// the shared runManager helper. Reads `hosts_entries:` from linux.yaml; edits
+// /etc/hosts between `# BEGIN linuxctl` / `# END linuxctl` markers idempotently
+// (linuxctl#51 — Phase C blocker for /lab-up).
 func newHostsCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "hosts",
-		Short: "Manage hosts state (plan / apply / verify)",
+		Use:   "hosts [env.yaml|linux.yaml]",
+		Short: "Manage /etc/hosts state (plan / apply / verify)",
 	}
 	cmd.AddCommand(&cobra.Command{
-		Use:   "plan",
-		Short: "Preview hosts changes against the desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("hosts plan: not implemented") },
+		Use:   "plan [env.yaml|linux.yaml]",
+		Short: "Preview /etc/hosts changes against the desired state",
+		RunE:  runManager("hosts", actionPlan),
 	})
 	cmd.AddCommand(&cobra.Command{
-		Use:   "apply",
-		Short: "Apply hosts changes to reach the desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("hosts apply: not implemented") },
+		Use:   "apply [env.yaml|linux.yaml]",
+		Short: "Apply /etc/hosts changes (rewrites managed block only)",
+		RunE:  runManager("hosts", actionApply),
 	})
 	cmd.AddCommand(&cobra.Command{
-		Use:   "verify",
-		Short: "Verify observed hosts state matches desired state",
-		RunE:  func(_ *cobra.Command, _ []string) error { return fmt.Errorf("hosts verify: not implemented") },
+		Use:   "verify [env.yaml|linux.yaml]",
+		Short: "Verify observed /etc/hosts managed block matches desired state",
+		RunE:  runManager("hosts", actionVerify),
 	})
 	return cmd
 }

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -62,6 +62,11 @@ type globalFlags struct {
 	dryRun  bool
 	license string
 	verbose bool
+	// reformatFilesystems opts in to destructive mkfs on LVs that already
+	// hold a filesystem of a different type than the manifest requests
+	// (linuxctl#52). Default false: disk.Plan returns an explicit error so
+	// `linuxctl stack apply` can no longer silently destroy data.
+	reformatFilesystems bool
 }
 
 var gf globalFlags
@@ -101,6 +106,8 @@ func NewRootCmd(info BuildInfo) *cobra.Command {
 	pf.BoolVar(&gf.dryRun, "dry-run", false, "Alias for plan; never mutate")
 	pf.StringVar(&gf.license, "license", "", "Override ~/.linuxctl/license.jwt")
 	pf.BoolVarP(&gf.verbose, "verbose", "v", false, "Verbose logging")
+	pf.BoolVar(&gf.reformatFilesystems, "reformat-filesystems", false,
+		"Allow disk apply to mkfs over an existing, mismatched filesystem (DESTRUCTIVE)")
 
 	// Groups.
 	cmd.AddCommand(newConfigCmd())

--- a/internal/root/root_test.go
+++ b/internal/root/root_test.go
@@ -583,11 +583,15 @@ func TestDir_UnknownOp(t *testing.T) {
 	}
 }
 
-// ---- stub subsystem commands (service/sysctl/limits/firewall/hosts/
-// network/selinux all stubs) ------------------------------------------------
+// ---- stub subsystem commands (service/sysctl/limits/network/selinux still
+// stubs; firewall + hosts wired in linuxctl#51) ------------------------------
 
 func TestStubSubsystems_AllReturnNotImplemented(t *testing.T) {
-	subsystems := []string{"service", "sysctl", "limits", "firewall", "hosts", "network", "selinux"}
+	// firewall + hosts removed: now wired to runManager via the registered
+	// HostsManager + FirewallManager (linuxctl#51 — Phase C blocker for
+	// /lab-up). Their wiring is exercised in TestHosts_WiredToRunManager
+	// and TestFirewall_WiredToRunManager below.
+	subsystems := []string{"service", "sysctl", "limits", "network", "selinux"}
 	verbs := []string{"plan", "apply", "verify"}
 	for _, s := range subsystems {
 		for _, v := range verbs {
@@ -596,6 +600,51 @@ func TestStubSubsystems_AllReturnNotImplemented(t *testing.T) {
 				t.Errorf("%s %s: want not implemented, got %v", s, v, err)
 			}
 		}
+	}
+}
+
+// TestHosts_WiredToRunManager confirms `linuxctl hosts plan/apply/verify` no
+// longer return "not implemented" — they now invoke the registered HostsManager
+// via runManager. With an empty linux.yaml (no hosts_entries), Plan returns
+// no changes; apply short-circuits cleanly; verify reports OK.
+//
+// linuxctl#51 — Phase C blocker for /lab-up: stack manifests' `hosts_entries:`
+// blocks were silently dropped because the per-subsystem CLI was a stub.
+//
+// We assert the error path (no "not implemented" in the returned error) rather
+// than capture stdout, because runManager prints with fmt.Printf to the real
+// process stdout (matching the convention shared with disk/mount commands).
+func TestHosts_WiredToRunManager(t *testing.T) {
+	linux := writeMinimalLinux(t)
+	for _, verb := range []string{"plan", "apply", "verify"} {
+		_, err := executeCmd(t, "hosts", verb, linux)
+		if err != nil && strings.Contains(err.Error(), "not implemented") {
+			t.Errorf("hosts %s: still returns 'not implemented': %v", verb, err)
+		}
+	}
+}
+
+// TestFirewall_WiredToRunManager mirrors the hosts wiring test for the
+// firewall subsystem (linuxctl#51).
+func TestFirewall_WiredToRunManager(t *testing.T) {
+	linux := writeMinimalLinux(t)
+	for _, verb := range []string{"plan", "apply", "verify"} {
+		_, err := executeCmd(t, "firewall", verb, linux)
+		if err != nil && strings.Contains(err.Error(), "not implemented") {
+			t.Errorf("firewall %s: still returns 'not implemented': %v", verb, err)
+		}
+	}
+}
+
+// TestReformatFilesystemsFlag_Exposed confirms the global flag added for the
+// disk-idempotency fix is reachable from the CLI (linuxctl#52).
+func TestReformatFilesystemsFlag_Exposed(t *testing.T) {
+	out, err := executeCmd(t, "--help")
+	if err != nil {
+		t.Fatalf("help: %v", err)
+	}
+	if !strings.Contains(out, "--reformat-filesystems") {
+		t.Errorf("--help missing --reformat-filesystems flag: %s", out)
 	}
 }
 

--- a/internal/root/runtime.go
+++ b/internal/root/runtime.go
@@ -134,21 +134,44 @@ func deadlineCtx() (context.Context, context.CancelFunc) {
 // method (any signature accepting a session.Session), we call it via type
 // switch on the known concrete types. Unknown managers pass through.
 func bindSession(m managers.Manager, sess session.Session) managers.Manager {
+	if sess == nil {
+		return m
+	}
+	// Mirror the orchestrator's bindSession (pkg/apply/orchestrator.go) so
+	// every per-subsystem CLI command (`linuxctl hosts apply`, `linuxctl
+	// firewall apply`, …) gets a session-bound manager. Without this, single-
+	// manager invocations bypass session wiring and fail at Plan/Apply with
+	// session-required errors (linuxctl#51).
 	switch v := m.(type) {
-	case interface {
-		WithSession(session.Session) *managers.DiskManager
-	}:
+	case *managers.DiskManager:
+		// Honor --reformat-filesystems on every disk-manager invocation
+		// (single-manager CLI + orchestrator alike). linuxctl#52.
+		return v.WithSession(sess).WithReformatFilesystems(gf.reformatFilesystems)
+	case *managers.MountManager:
 		return v.WithSession(sess)
-	case interface {
-		WithSession(session.Session) *managers.MountManager
-	}:
+	case *managers.UserManager:
+		return v.WithSession(sess)
+	case *managers.PackageManager:
+		return v.WithSession(sess)
+	case *managers.DirManager:
+		return v.WithSession(sess)
+	case *managers.LimitsManager:
+		return v.WithSession(sess)
+	case *managers.SELinuxManager:
+		return v.WithSession(sess)
+	case *managers.SysctlManager:
+		return v.WithSession(sess)
+	case *managers.ServiceManager:
+		return v.WithSession(sess)
+	case *managers.FirewallManager:
+		return v.WithSession(sess)
+	case *managers.HostsManager:
+		return v.WithSession(sess)
+	case *managers.NetworkManager:
+		return v.WithSession(sess)
+	case *managers.SSHAuthManager:
 		return v.WithSession(sess)
 	}
-	// Try a broader reflective-style match via known signatures of other
-	// managers. Since we can't import their concrete types without an import
-	// cycle, we rely on the interface-based dispatch above plus fallthrough
-	// for managers that wire their session through package-level globals or
-	// managers.All().
 	return m
 }
 
@@ -169,6 +192,16 @@ func desiredFor(linux *config.Linux, name string) managers.Spec {
 		return linux.Directories
 	case "package":
 		return packagesSpec(linux.Packages)
+	case "hosts":
+		// HostsManager.castHostEntries accepts both *config.Linux and
+		// []config.HostEntry; pass the slice directly so an empty
+		// hosts_entries: produces a clean no-op plan rather than the
+		// whole Linux struct dragging in unrelated fields. linuxctl#51.
+		return linux.HostsEntries
+	case "firewall":
+		// FirewallManager.castFirewall accepts *config.Firewall directly.
+		// Pass the typed pointer (may be nil → no-op plan). linuxctl#51.
+		return linux.Firewall
 	}
 	return linux
 }

--- a/pkg/apply/orchestrator.go
+++ b/pkg/apply/orchestrator.go
@@ -56,6 +56,10 @@ type Orchestrator struct {
 	Managers        []managers.Manager
 	DryRun          bool
 	ContinueOnError bool
+	// ReformatFilesystems is forwarded to DiskManager during bindSession so
+	// `linuxctl --reformat-filesystems apply apply` opts in to destructive
+	// mkfs on mismatched filesystems (linuxctl#52). Default false.
+	ReformatFilesystems bool
 
 	// applied records, per manager name, the changes we applied in the last
 	// successful Apply. Used by Rollback.
@@ -184,7 +188,7 @@ func (o *Orchestrator) bindSession(m managers.Manager) managers.Manager {
 	}
 	switch v := m.(type) {
 	case *managers.DiskManager:
-		return v.WithSession(o.Session)
+		return v.WithSession(o.Session).WithReformatFilesystems(o.ReformatFilesystems)
 	case *managers.MountManager:
 		return v.WithSession(o.Session)
 	case *managers.UserManager:

--- a/pkg/managers/disk.go
+++ b/pkg/managers/disk.go
@@ -18,8 +18,21 @@ import (
 //
 // Safety: DiskManager only creates. It never removes PVs/VGs/LVs or reshapes
 // existing filesystems. Rollback reverses in-session creations only.
+//
+// mkfs idempotency (linuxctl#52): Plan probes blkid on each desired LV. If
+// the existing filesystem matches the manifest `fs:` value, mkfs is skipped.
+// If a different filesystem is present, Plan returns an error with the
+// remediation hint to set --reformat-filesystems (a.k.a.
+// DiskManager.ReformatFilesystems = true). If no filesystem is present, mkfs
+// proceeds as before.
 type DiskManager struct {
 	Session session.Session
+
+	// ReformatFilesystems opts in to destructive mkfs over an existing,
+	// mismatched filesystem (e.g. ext4 found where manifest says xfs).
+	// Default false → Plan errors with remediation. Wired from the global
+	// `--reformat-filesystems` flag in internal/root. linuxctl#52.
+	ReformatFilesystems bool
 }
 
 // NewDiskManager returns a disk manager bound to sess. sess may be nil for
@@ -30,6 +43,14 @@ func NewDiskManager() *DiskManager { return &DiskManager{} }
 func (m *DiskManager) WithSession(sess session.Session) *DiskManager {
 	cp := *m
 	cp.Session = sess
+	return &cp
+}
+
+// WithReformatFilesystems returns a copy of m with ReformatFilesystems
+// overridden. Used by `linuxctl --reformat-filesystems …` callers (linuxctl#52).
+func (m *DiskManager) WithReformatFilesystems(b bool) *DiskManager {
+	cp := *m
+	cp.ReformatFilesystems = b
 	return &cp
 }
 
@@ -120,6 +141,18 @@ func (m *DiskManager) discover(ctx context.Context) (*discovery, error) {
 			for _, rep := range r.Report {
 				for _, lv := range rep.LV {
 					d.LVs[lv.VGName+"/"+lv.LVName] = true
+					// Probe filesystem on each LV via blkid. The
+					// device path is the canonical /dev/<vg>/<lv>
+					// symlink. blkid prints "TYPE=\"xfs\"" on
+					// stdout when a filesystem is present and
+					// exits non-zero (and prints nothing) when
+					// the LV has no signature. We tolerate both
+					// outcomes silently — only successful TYPE=
+					// matches are recorded. linuxctl#52.
+					dev := "/dev/" + lv.VGName + "/" + lv.LVName
+					if fs := probeFSType(ctx, m.Session, dev); fs != "" {
+						d.FSType[dev] = fs
+					}
 				}
 			}
 		}
@@ -319,15 +352,34 @@ func (m *DiskManager) planDisk(ctx context.Context, disc *discovery, device, vg 
 				RollbackCmd: fmt.Sprintf("lvremove -f -y %s", dev),
 			})
 		}
-		// FS (we don't know fs-by-device without blkid; conservative: always plan mkfs if LV is new).
-		changes = append(changes, Change{
-			Manager:     "disk",
-			Target:      dev,
-			Action:      "create",
-			Hazard:      HazardDestructive,
-			After:       map[string]any{"op": "mkfs", "device": dev, "fstype": lv.FS},
-			RollbackCmd: "",
-		})
+		// FS — gate mkfs by blkid probe (linuxctl#52). Discovery
+		// populates disc.FSType via blkid for every existing LV.
+		//
+		//   - existing FS == manifest fs:  → skip mkfs (idempotent)
+		//   - existing FS != manifest fs:  → error unless ReformatFilesystems
+		//   - no existing FS              → mkfs (original behaviour)
+		existingFS := disc.FSType[dev]
+		switch {
+		case existingFS == lv.FS:
+			// Already correct — emit nothing for the FS step. Test
+			// observability is preserved via disc.FSType[dev].
+		case existingFS != "" && existingFS != lv.FS && !m.ReformatFilesystems:
+			return nil, fmt.Errorf(
+				"disk: %s already has filesystem %q but manifest requests %q; "+
+					"refusing to reformat without --reformat-filesystems "+
+					"(this would destroy existing data)",
+				dev, existingFS, lv.FS)
+		default:
+			// no FS, or operator opted in via --reformat-filesystems
+			changes = append(changes, Change{
+				Manager:     "disk",
+				Target:      dev,
+				Action:      "create",
+				Hazard:      HazardDestructive,
+				After:       map[string]any{"op": "mkfs", "device": dev, "fstype": lv.FS},
+				RollbackCmd: "",
+			})
+		}
 		if lv.MountPoint != "" {
 			// fstab entry.
 			fstabLine := fmt.Sprintf("%s %s %s %s 0 0", dev, lv.MountPoint, lv.FS, "defaults")
@@ -527,6 +579,28 @@ func defaultStr(s, dflt string) string {
 
 func shSingleQuote(s string) string {
 	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+// probeFSType returns the filesystem type reported by blkid for dev, or "" if
+// no signature is present (or blkid is unavailable). Used by disk.Plan to
+// gate mkfs idempotency (linuxctl#52).
+//
+// Output of `blkid -o value -s TYPE /dev/<dev>`:
+//
+//	xfs       → existing xfs filesystem
+//	ext4      → existing ext4 filesystem
+//	(empty)   → no filesystem signature
+//
+// blkid exits non-zero on no-signature; we treat any error as "no fs" rather
+// than a hard failure. The Session interface returns combined-stderr in the
+// error case, but we only care about the trimmed stdout.
+func probeFSType(ctx context.Context, sess session.Session, dev string) string {
+	if sess == nil {
+		return ""
+	}
+	cmd := fmt.Sprintf("blkid -o value -s TYPE %s 2>/dev/null || true", dev)
+	out, _, _ := sess.RunSudo(ctx, cmd)
+	return strings.TrimSpace(out)
 }
 
 func init() { Register(NewDiskManager()) }

--- a/pkg/managers/disk_test.go
+++ b/pkg/managers/disk_test.go
@@ -274,6 +274,130 @@ func TestDiskManager_Rollback(t *testing.T) {
 	}
 }
 
+// ---- mkfs idempotency (linuxctl#52) --------------------------------------
+
+// existingLVMock builds a mock with one LV (datavg/data) already present and
+// blkid returning the supplied filesystem type for /dev/datavg/data.
+func existingLVMock(blkidFS string) *fullMockSession {
+	ms := newFullMock().
+		on("pvs", `{"report":[{"pv":[{"pv_name":"/dev/sdb","vg_name":"datavg"}]}]}`, nil).
+		on("vgs", `{"report":[{"vg":[{"vg_name":"datavg"}]}]}`, nil).
+		on("lvs", `{"report":[{"lv":[{"lv_name":"data","vg_name":"datavg"}]}]}`, nil).
+		on("findmnt", `{"filesystems":[]}`, nil).
+		on("blkid -o value -s TYPE /dev/datavg/data", blkidFS, nil)
+	ms.exists["/dev/sdb"] = true
+	return ms
+}
+
+// TestDiskManager_Plan_MkfsSkipsExistingMatchingFS — when the LV already has
+// the requested filesystem, mkfs is omitted from the plan. linuxctl#52.
+func TestDiskManager_Plan_MkfsSkipsExistingMatchingFS(t *testing.T) {
+	ms := existingLVMock("xfs")
+	d := NewDiskManager().WithSession(ms)
+	layout := &config.DiskLayout{
+		Additional: []config.AdditionalDisk{
+			{Device: "/dev/sdb", VGName: "datavg",
+				LogicalVolumes: []config.LogicalVolume{
+					{Name: "data", Size: "10G", FS: "xfs", MountPoint: "/data"},
+				}},
+		},
+	}
+	changes, err := d.PlanLayout(context.Background(), layout)
+	if err != nil {
+		t.Fatalf("PlanLayout: %v", err)
+	}
+	for _, c := range changes {
+		after, _ := c.After.(map[string]any)
+		if op, _ := after["op"].(string); op == "mkfs" {
+			t.Errorf("did not expect mkfs when filesystem already matches; got change: %+v", c)
+		}
+	}
+}
+
+// TestDiskManager_Plan_MkfsErrorsOnMismatch — when the LV holds ext4 but the
+// manifest demands xfs, Plan returns an error with the remediation hint.
+// linuxctl#52.
+func TestDiskManager_Plan_MkfsErrorsOnMismatch(t *testing.T) {
+	ms := existingLVMock("ext4")
+	d := NewDiskManager().WithSession(ms)
+	layout := &config.DiskLayout{
+		Additional: []config.AdditionalDisk{
+			{Device: "/dev/sdb", VGName: "datavg",
+				LogicalVolumes: []config.LogicalVolume{
+					{Name: "data", Size: "10G", FS: "xfs", MountPoint: "/data"},
+				}},
+		},
+	}
+	_, err := d.PlanLayout(context.Background(), layout)
+	if err == nil {
+		t.Fatal("expected error for mismatched filesystem; got nil")
+	}
+	for _, want := range []string{"ext4", "xfs", "--reformat-filesystems"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error message missing %q: %v", want, err)
+		}
+	}
+}
+
+// TestDiskManager_Plan_MkfsProceedsWhenNoFS — no existing filesystem ⇒ mkfs is
+// emitted as before. linuxctl#52.
+func TestDiskManager_Plan_MkfsProceedsWhenNoFS(t *testing.T) {
+	ms := existingLVMock("") // blkid returns nothing → no FS
+	d := NewDiskManager().WithSession(ms)
+	layout := &config.DiskLayout{
+		Additional: []config.AdditionalDisk{
+			{Device: "/dev/sdb", VGName: "datavg",
+				LogicalVolumes: []config.LogicalVolume{
+					{Name: "data", Size: "10G", FS: "xfs", MountPoint: "/data"},
+				}},
+		},
+	}
+	changes, err := d.PlanLayout(context.Background(), layout)
+	if err != nil {
+		t.Fatalf("PlanLayout: %v", err)
+	}
+	found := false
+	for _, c := range changes {
+		after, _ := c.After.(map[string]any)
+		if op, _ := after["op"].(string); op == "mkfs" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mkfs change when no filesystem exists; got: %+v", changes)
+	}
+}
+
+// TestDiskManager_Plan_ReformatFilesystemsOverridesMismatch — operator opts in
+// to destructive reformat via WithReformatFilesystems(true). Plan no longer
+// errors; mkfs is emitted. linuxctl#52.
+func TestDiskManager_Plan_ReformatFilesystemsOverridesMismatch(t *testing.T) {
+	ms := existingLVMock("ext4")
+	d := NewDiskManager().WithSession(ms).WithReformatFilesystems(true)
+	layout := &config.DiskLayout{
+		Additional: []config.AdditionalDisk{
+			{Device: "/dev/sdb", VGName: "datavg",
+				LogicalVolumes: []config.LogicalVolume{
+					{Name: "data", Size: "10G", FS: "xfs", MountPoint: "/data"},
+				}},
+		},
+	}
+	changes, err := d.PlanLayout(context.Background(), layout)
+	if err != nil {
+		t.Fatalf("PlanLayout (reformat opt-in): %v", err)
+	}
+	found := false
+	for _, c := range changes {
+		after, _ := c.After.(map[string]any)
+		if op, _ := after["op"].(string); op == "mkfs" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected mkfs change with --reformat-filesystems; got: %+v", changes)
+	}
+}
+
 func TestDiskManager_Name(t *testing.T) {
 	if NewDiskManager().Name() != "disk" {
 		t.Errorf("wrong name")

--- a/pkg/presets/data/users_groups/oracle-single.yaml
+++ b/pkg/presets/data/users_groups/oracle-single.yaml
@@ -8,22 +8,39 @@ metadata:
     Oracle Database single-instance install with role-separation
     (Oracle DB owner + Grid Infrastructure owner). Aligns with the
     Oracle Database 19c Linux Install Guide §6 "Creating Operating
-    System Privileges Groups, Users, and Directories".
-    Even single-instance installs need 'grid' for ASM/Oracle Restart.
-  version: "2026-04-30"
+    System Privileges Groups, Users, and Directories"
+    (https://docs.oracle.com/en/database/oracle/oracle-database/19/ladbi/about-oracle-installation-user-accounts.html).
+
+    GIDs follow Oracle's documented defaults so RPM-installed binaries
+    that hard-code numeric IDs (oracle-database-preinstall-19c) stay
+    in alignment with our manually managed users.
+
+    Even single-instance installs need 'grid' for ASM / Oracle Restart;
+    asmca + runInstaller in /lab-up Phase D.1+D.2 require this user
+    to exist before they execute (linuxctl#53).
+  version: "2026-05-03"
 spec:
   users_groups:
     groups:
       - { name: "oinstall", gid: 54321 }   # OINSTALL — Oracle Inventory
-      - { name: "dba",      gid: 54322 }   # OSDBA  — DB administrators
-      - { name: "asmadmin", gid: 54323 }   # OSASM  — ASM administrators
-      - { name: "asmdba",   gid: 54324 }   # OSDBA for ASM
-      - { name: "asmoper",  gid: 54325 }   # OSOPER for ASM
+      - { name: "dba",      gid: 54322 }   # OSDBA   — DB administrators
+      - { name: "oper",     gid: 54323 }   # OSOPER  — DB operators
+      - { name: "backupdba", gid: 54324 }  # OSBACKUPDBA
+      - { name: "dgdba",    gid: 54325 }   # OSDGDBA — Data Guard
+      - { name: "kmdba",    gid: 54326 }   # OSKMDBA — TDE / key mgmt
+      - { name: "asmadmin", gid: 54327 }   # OSASM   — ASM administrators (grid-only)
+      - { name: "asmdba",   gid: 54328 }   # OSDBA for ASM
+      - { name: "asmoper",  gid: 54329 }   # OSOPER for ASM (grid-only)
     users:
       # Oracle DB owner. Primary group = oinstall (matches what the
       # oracle-database-preinstall-19c RPM creates; preset kept idempotent).
+      # Membership: dba (admin), oper (operator), asmdba (read ASM).
+      # NOT asmadmin / asmoper — those are reserved for the grid user
+      # so privilege boundaries between DB + GI homes stay enforced
+      # (linuxctl#53).
       - { name: "oracle", uid: 54321, gid: "oinstall",
-          groups: ["dba", "asmdba"] }
-      # Grid Infrastructure / ASM / Oracle Restart owner.
+          groups: ["dba", "oper", "backupdba", "dgdba", "kmdba", "asmdba"] }
+      # Grid Infrastructure / ASM / Oracle Restart owner. Owns the GRID
+      # ORACLE_HOME and runs asmca + runInstaller for Phase D.2.
       - { name: "grid",   uid: 54322, gid: "oinstall",
           groups: ["asmadmin", "asmdba", "asmoper", "dba"] }

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -307,6 +307,94 @@ func TestEmbeddedPresets_Oracle19cLimitsByteForByte(t *testing.T) {
 	}
 }
 
+// TestEmbeddedPresets_OracleSingle_HasGridUser is a regression gate for
+// linuxctl#53. /lab-up Phase D.1 (oracle-asm-configure) and Phase D.2
+// (oracle-grid-install) both need the grid user to own GRID_HOME and run
+// asmca / runInstaller. The oracle-single preset (used by every
+// oracle-single-* bundle) MUST ship with both oracle + grid users; with the
+// correct ASM groups; and oracle MUST NOT be in asmadmin or asmoper (those
+// are reserved for grid).
+func TestEmbeddedPresets_OracleSingle_HasGridUser(t *testing.T) {
+	p, err := ResolveCategory("users_groups", "oracle-single", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ug, err := UsersGroupsSpec(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Index users + groups for assertions.
+	users := map[string]int{}
+	for _, u := range ug.Users {
+		users[u.Name] = u.UID
+	}
+	groups := map[string]int{}
+	for _, g := range ug.Groups {
+		groups[g.Name] = g.GID
+	}
+
+	// Grid user — required for ASM/Oracle Restart.
+	gridUID, hasGrid := users["grid"]
+	if !hasGrid {
+		t.Fatal("oracle-single: missing grid user — Phase D.1/D.2 will fail")
+	}
+	if gridUID != 54322 {
+		t.Errorf("oracle-single: grid uid want 54322, got %d", gridUID)
+	}
+
+	// Oracle user — must remain present.
+	if _, ok := users["oracle"]; !ok {
+		t.Fatal("oracle-single: missing oracle user")
+	}
+
+	// Required ASM groups (Oracle 19c standard GIDs).
+	for name, wantGID := range map[string]int{
+		"asmadmin": 54327,
+		"asmdba":   54328,
+		"asmoper":  54329,
+	} {
+		got, ok := groups[name]
+		if !ok {
+			t.Errorf("oracle-single: missing ASM group %q", name)
+			continue
+		}
+		if got != wantGID {
+			t.Errorf("oracle-single: %s gid want %d, got %d", name, wantGID, got)
+		}
+	}
+
+	// Oracle user MUST NOT be in asmadmin / asmoper — those are grid-only.
+	for _, u := range ug.Users {
+		if u.Name != "oracle" {
+			continue
+		}
+		for _, g := range u.Groups {
+			if g == "asmadmin" || g == "asmoper" {
+				t.Errorf("oracle-single: oracle user MUST NOT be in %q (reserved for grid)", g)
+			}
+		}
+	}
+
+	// Grid user MUST be in asmadmin/asmdba/asmoper/dba.
+	for _, u := range ug.Users {
+		if u.Name != "grid" {
+			continue
+		}
+		want := map[string]bool{"asmadmin": false, "asmdba": false, "asmoper": false, "dba": false}
+		for _, g := range u.Groups {
+			if _, ok := want[g]; ok {
+				want[g] = true
+			}
+		}
+		for g, found := range want {
+			if !found {
+				t.Errorf("oracle-single: grid user missing required supplementary group %q", g)
+			}
+		}
+	}
+}
+
 func TestResolve_AmbiguousName(t *testing.T) {
 	// oracle-19c exists in packages, sysctl, limits → ambiguous.
 	if _, err := Resolve("oracle-19c", nil); err == nil {


### PR DESCRIPTION
## Summary

Three blockers surfaced during /lab-up Phase C live execution against the ext3+ext4 lab. All three affected `linuxctl stack apply` and adjacent paths.

- **#51** — `linuxctl hosts apply` + `linuxctl firewall apply` were CLI stubs returning `Error: <subsystem> apply: not implemented`. The managers themselves are fully implemented; only the CLI wiring was missing. Both commands now route through the shared `runManager` helper; `internal/root/runtime.go` `bindSession` + `desiredFor` extended to cover all 13 managers.
- **#52** — `disk apply` unconditionally re-emitted `mkfs` for every LV in the manifest, halting apply chains on re-run when LVs already held a filesystem. Discovery now probes `blkid -o value -s TYPE`; Plan skips mkfs on match, errors on mismatch with explicit remediation, falls through on no-FS. Adds `--reformat-filesystems` global flag for destructive opt-in.
- **#53** — `oracle-single` preset (used by every `oracle-single-*` bundle) had ASM group GIDs misaligned with Oracle 19c documented defaults (54323/24/25 vs 54327/28/29) and omitted role-separation groups. Aligned to upstream; `oracle` user now in `[dba, oper, backupdba, dgdba, kmdba, asmdba]`; `grid` remains in `[asmadmin, asmdba, asmoper, dba]`. Grid user was already present (issue title was misleading) — the real fixes are the GID alignment + missing role groups.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./... -count=1` green (all packages — internal/root, pkg/apply, pkg/config, pkg/license, pkg/managers, pkg/presets, pkg/session)
- [x] 4 new disk idempotency tests cover: skip-on-match, error-on-mismatch with remediation hint in message, mkfs-when-no-FS, `--reformat-filesystems` override
- [x] 3 new CLI wiring tests cover: hosts plan/apply/verify wired, firewall plan/apply/verify wired, `--reformat-filesystems` flag exposed in `--help`
- [x] 1 new oracle-single regression gate: grid user present + GID 54322; all 3 ASM groups present at correct GIDs; oracle user NOT in asmadmin/asmoper; grid user IS in [asmadmin, asmdba, asmoper, dba]
- [x] Existing `TestStubSubsystems_AllReturnNotImplemented` updated — firewall + hosts removed from the stub list (still asserts service/sysctl/limits/network/selinux remain stubs)
- [ ] **Operator review before merge** — do not auto-merge. Live re-run of /lab-up Phase C against ext3+ext4 lab is the real validation gate.

Closes #51 #52 #53.