### PR TITLE
feat(presets): oracle-single-19c OL9 prereqs (gcc, gcc-c++, make, binutils) (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,39 @@
 # Changelog
+## v2026.05.03.2 — 2026-05-03
+
+### feat(presets): oracle-single-19c OL9 prereqs (gcc, gcc-c++, make, binutils) (#57)
+
+Live failure during /lab-up Phase D.2 (oracle-grid-install) on `ext3adm1` +
+`ext4adm1` (OL9.7) revealed that `oracle-database-preinstall-19c` does NOT
+pull a working C toolchain on Oracle Linux 9 — runInstaller exited with
+`gcc: command not found` and `g++: command not found` during the link step.
+
+The `oracle-19c` packages preset (consumed by every `oracle-single-19c` /
+`oracle-rac-19c` bundle) now installs `gcc`, `gcc-c++`, `make`, and
+`binutils` alongside the preinstall metapackage. No bundle wiring change
+needed — the existing bundle already references this preset.
+
+**Out of scope for this PR (deferred to a schema enhancement):**
+
+- `ol9_codeready_builder` repo enablement (provides `glibc-static` + dev
+  packages). Needs a new `repos_enable:` capability in the bundle schema.
+- `/usr/lib64/libpthread_nonshared.a` stub file (glibc-on-OL9 split-out
+  workaround for runInstaller's genclntsh; a properly-formed empty `ar`
+  archive with the 8-byte `!<arch>\n` magic header satisfies the link
+  step). Needs a new `files:` capability in the bundle schema.
+- `cvuqdisk` RPM install. The RPM ships INSIDE the Grid Home zip at
+  `$GRID_HOME/cv/rpm/cvuqdisk-*.rpm` and is therefore not available in any
+  yum repo at preset-apply time. The `/oracle-grid-install` skill (infra
+  repo) handles this at Grid-extraction time as Step 0a.
+
+Until the schema additions land, the `/oracle-grid-install` and
+`/oracle-dbhome-install` skills must handle the codeready repo enable + the
+libpthread stub + the cvuqdisk RPM install directly.
+
+Test additions: 1 new regression gate in `pkg/presets/presets_test.go`
+(`TestEmbeddedPresets_Oracle19c_OL9BuildDeps`) asserts the four new
+packages are present and `cvuqdisk` is absent.
+
 ## v2026.05.03.1 — 2026-05-03
 
 ### fix(lab-up): Phase C blockers — hosts/firewall CLI + disk idempotency + oracle-single grid user (#51 #52 #53)

--- a/pkg/presets/data/packages/oracle-19c.yaml
+++ b/pkg/presets/data/packages/oracle-19c.yaml
@@ -4,11 +4,39 @@ metadata:
   name: oracle-19c
   category: packages
   tier: community
-  source: "Oracle Linux oracle-database-preinstall-19c metapackage + kmod-oracleasm"
-  version: "2026-04-22"
+  source: "Oracle Linux oracle-database-preinstall-19c metapackage + kmod-oracleasm + OL9 19c build deps (linuxctl#57)"
+  version: "2026-05-03"
 spec:
   packages:
     install:
+      # Core Oracle 19c metapackage. Pulls glibc-devel, libaio-devel, etc.
+      # On OL9 this does NOT pull a working C toolchain — see notes below.
       - oracle-database-preinstall-19c
+      # ASM kernel module (RPM-only on OL/RHEL family).
       - kmod-oracleasm
+      # CIFS for the /smb/software install-source mount.
       - cifs-utils
+
+      # OL9 Oracle 19c build prereqs (linuxctl#57).
+      # The preinstall-19c metapackage on OL9 omits the C/C++ compiler that
+      # runInstaller's link step needs (e.g. for genclntsh / libsqlplus.so).
+      # Live failure on ext3adm1 + ext4adm1 (OL9.7) — runInstaller exited
+      # with `gcc: command not found` and `g++: command not found`.
+      - gcc
+      - gcc-c++
+      - make
+      - binutils
+
+      # NOTE: cvuqdisk RPM (cluvfy disk-info helper, PRVG-11550 if missing)
+      # ships INSIDE the Grid Home zip at $GRID_HOME/cv/rpm/cvuqdisk-*.rpm.
+      # Installation is therefore a Grid-extraction-time step — see the
+      # /oracle-grid-install skill (infrastructure repo) Step 0a — and is
+      # NOT installed by this preset because the RPM is not in any yum repo.
+      #
+      # NOTE: ol9_codeready_builder repo enablement and the
+      # /usr/lib64/libpthread_nonshared.a stub file (glibc-on-OL9 split-out
+      # workaround for runInstaller's genclntsh) need new bundle capabilities
+      # (`repos_enable:` + `files:`) which do not yet exist in the preset
+      # schema. Tracked as follow-up after linuxctl#57. For now, the
+      # /oracle-grid-install + /oracle-dbhome-install skills handle those two
+      # OL9-specific shims directly.

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -395,6 +395,43 @@ func TestEmbeddedPresets_OracleSingle_HasGridUser(t *testing.T) {
 	}
 }
 
+// TestEmbeddedPresets_Oracle19c_OL9BuildDeps is a regression gate for
+// linuxctl#57. /lab-up Phase D.2 (oracle-grid-install) on OL9 fails with
+// "gcc: command not found" because oracle-database-preinstall-19c does NOT
+// pull a working C toolchain on OL9. The oracle-19c packages preset MUST
+// install gcc + gcc-c++ + make alongside the preinstall metapackage.
+//
+// cvuqdisk is intentionally NOT in this preset — it ships inside the Grid
+// Home zip at $GRID_HOME/cv/rpm/ and is installed by the
+// /oracle-grid-install skill at extraction time.
+func TestEmbeddedPresets_Oracle19c_OL9BuildDeps(t *testing.T) {
+	p, err := ResolveCategory("packages", "oracle-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pp, err := PackagesSpec(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"oracle-database-preinstall-19c", // baseline
+		"kmod-oracleasm",                 // baseline
+		"cifs-utils",                     // baseline
+		"gcc",                            // linuxctl#57
+		"gcc-c++",                        // linuxctl#57
+		"make",                           // linuxctl#57
+		"binutils",                       // linuxctl#57
+	} {
+		if !containsStr(pp.Install, want) {
+			t.Errorf("oracle-19c packages preset: missing required package %q (install=%v)", want, pp.Install)
+		}
+	}
+	// cvuqdisk MUST NOT be in this preset — it's a Grid-extraction-time step.
+	if containsStr(pp.Install, "cvuqdisk") {
+		t.Error("oracle-19c packages preset: cvuqdisk MUST NOT be here (it ships inside Grid zip; install via /oracle-grid-install Step 0a)")
+	}
+}
+
 func TestResolve_AmbiguousName(t *testing.T) {
 	// oracle-19c exists in packages, sysctl, limits → ambiguous.
 	if _, err := Resolve("oracle-19c", nil); err == nil {


### PR DESCRIPTION
## Summary

Live failure during `/lab-up` Phase D.2 (oracle-grid-install) on `ext3adm1` + `ext4adm1` (OL9.7): `oracle-database-preinstall-19c` does NOT pull a working C toolchain on OL9. runInstaller's link step exited with `gcc: command not found` and `g++: command not found`.

This PR adds `gcc`, `gcc-c++`, `make`, `binutils` to the `oracle-19c` packages preset. No bundle wiring change needed — the existing `oracle-single-19c` / `oracle-rac-19c` bundles already reference this preset.

## Scope decision

The original issue called for three additional capabilities:

1. **`gcc`/`gcc-c++`/`make`/`binutils`** — shipped here. Pure additive package list change, fits the existing `Packages` schema.
2. **`ol9_codeready_builder` repo enable** — deferred. Requires a new `repos_enable:` capability + new manager (no `repos` plumbing exists in `pkg/managers/` or `pkg/config/linux.go` today).
3. **`/usr/lib64/libpthread_nonshared.a` stub file** — deferred. Requires a new `files:` capability + new manager.
4. **`cvuqdisk` RPM install** — explicitly NOT in this preset. The RPM ships inside the Grid Home zip (`\$GRID_HOME/cv/rpm/cvuqdisk-*.rpm`) and is therefore not available at preset-apply time. The `/oracle-grid-install` skill (infrastructure repo) handles this at Grid-extraction time as Step 0a.

Items 2 + 3 need their own design doc + schema bump. Until they land, the `/oracle-grid-install` and `/oracle-dbhome-install` skills handle the codeready repo enable + the libpthread stub directly. A regression test (`TestEmbeddedPresets_Oracle19c_OL9BuildDeps`) explicitly asserts cvuqdisk is **not** in this preset to prevent accidental drift.

Closes #57.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./... -count=1` — all packages green (race flake in `pkg/session` SSH test is pre-existing, unrelated)
- [x] `go test ./pkg/presets/... -race -count=1` — green
- [x] New test `TestEmbeddedPresets_Oracle19c_OL9BuildDeps` asserts gcc/gcc-c++/make/binutils present + cvuqdisk absent
- [ ] Re-run `/lab-up` Phase D.2 against ext3+ext4 lab after merge to verify Grid runInstaller link step succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)