### PR TITLE
feat(presets): bundle repos_enable + files capabilities (#57 v2 — full closure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,47 @@
 # Changelog
+## v2026.05.03.3 — 2026-05-03
+
+### feat(presets): bundle repos_enable + files capabilities (#57 v2 — full closure)
+
+Closes the OL9 Oracle 19c prerequisite gap that the v1 PR (#58) left as
+out-of-scope. The `Bundle` schema now carries two inline capabilities
+alongside the existing per-category `*_preset` references:
+
+- `repos_enable: []` — list of dnf repository IDs that the new `repo`
+  manager idempotently enables via `dnf config-manager --set-enabled`.
+- `files: []` — list of `FileSpec` literal payloads that the new `file`
+  manager writes (base64-encoded body, mode/owner/group, optional
+  `create_only` for stub files that must defer to a later real
+  implementation).
+
+**New managers** — both implement the full `Manager` contract
+(plan / apply / verify / rollback) with idempotent re-apply:
+
+- `pkg/managers/repo.go` — RepoManager (12 unit tests)
+- `pkg/managers/file.go` — FileManager (13 unit tests)
+- CLI: `linuxctl repo {plan,apply,verify}` + `linuxctl file
+  {plan,apply,verify}` mirroring the firewall + hosts subcommand shape.
+
+**Schema + loader** — `config.Linux` gains `ReposEnable []string` +
+`Files []FileSpec`. The bundle expander surfaces inline lists via a
+companion `BundleInlineExpander` hook so `pkg/config` stays free of a
+`pkg/presets` import. Explicit manifest entries union with
+bundle-supplied entries; explicit wins on natural-key collision (repo
+ID / file path).
+
+**`oracle-single-19c` bundle now declares:**
+
+- `repos_enable: [ol9_codeready_builder]` — provides build-time deps
+  (libnsl, glibc-devel split-outs) that runInstaller's link step needs
+  on OL9 but `oracle-database-preinstall-19c` does not pull.
+- `files: [/usr/lib64/libpthread_nonshared.a]` — empty `ar` archive
+  stub (`!<arch>\n`, 8 bytes) that satisfies runInstaller's
+  `-lpthread_nonshared` link flag without polluting the runtime;
+  `create_only: true` so a later real RPM is not clobbered.
+
+**Tests:** 33 new unit tests across schema parse, repo manager,
+file manager, CLI wiring, and oracle-single-19c integration.
+
 ## v2026.05.03.2 — 2026-05-03
 
 ### feat(presets): oracle-single-19c OL9 prereqs (gcc, gcc-c++, make, binutils) (#57)

--- a/internal/root/file.go
+++ b/internal/root/file.go
@@ -1,0 +1,31 @@
+package root
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newFileCmd wires the file subsystem CLI to FileManager. Reads `files:`
+// from linux.yaml (typically populated by a bundle preset); writes literal
+// file payloads with idempotent body comparison. linuxctl#57.
+func newFileCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "file [env.yaml|linux.yaml]",
+		Short: "Manage literal file payloads (plan / apply / verify / rollback)",
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "plan [env.yaml|linux.yaml]",
+		Short: "Preview which files would be written",
+		RunE:  runManager("file", actionPlan),
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "apply [env.yaml|linux.yaml]",
+		Short: "Write any drifted files (idempotent: same body + mode → no-op)",
+		RunE:  runManager("file", actionApply),
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "verify [env.yaml|linux.yaml]",
+		Short: "Verify on-disk files match desired body + mode",
+		RunE:  runManager("file", actionVerify),
+	})
+	return cmd
+}

--- a/internal/root/repo.go
+++ b/internal/root/repo.go
@@ -1,0 +1,31 @@
+package root
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newRepoCmd wires the repo subsystem CLI to RepoManager. Reads
+// `repos_enable:` from linux.yaml (typically populated by a bundle preset);
+// idempotently enables the listed dnf repository IDs. linuxctl#57.
+func newRepoCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "repo [env.yaml|linux.yaml]",
+		Short: "Manage dnf repository enablement (plan / apply / verify / rollback)",
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "plan [env.yaml|linux.yaml]",
+		Short: "Preview which repos would be enabled",
+		RunE:  runManager("repo", actionPlan),
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "apply [env.yaml|linux.yaml]",
+		Short: "Enable any repos in repos_enable: that are currently disabled",
+		RunE:  runManager("repo", actionApply),
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "verify [env.yaml|linux.yaml]",
+		Short: "Verify all repos in repos_enable: are currently enabled",
+		RunE:  runManager("repo", actionVerify),
+	})
+	return cmd
+}

--- a/internal/root/root.go
+++ b/internal/root/root.go
@@ -128,6 +128,8 @@ func NewRootCmd(info BuildInfo) *cobra.Command {
 	cmd.AddCommand(newSSHCmd())
 	cmd.AddCommand(newSELinuxCmd())
 	cmd.AddCommand(newDirCmd())
+	cmd.AddCommand(newRepoCmd())
+	cmd.AddCommand(newFileCmd())
 
 	// Orchestrator + observation.
 	cmd.AddCommand(newApplyCmd())

--- a/internal/root/runtime.go
+++ b/internal/root/runtime.go
@@ -171,6 +171,10 @@ func bindSession(m managers.Manager, sess session.Session) managers.Manager {
 		return v.WithSession(sess)
 	case *managers.SSHAuthManager:
 		return v.WithSession(sess)
+	case *managers.RepoManager:
+		return v.WithSession(sess)
+	case *managers.FileManager:
+		return v.WithSession(sess)
 	}
 	return m
 }
@@ -202,6 +206,12 @@ func desiredFor(linux *config.Linux, name string) managers.Spec {
 		// FirewallManager.castFirewall accepts *config.Firewall directly.
 		// Pass the typed pointer (may be nil → no-op plan). linuxctl#51.
 		return linux.Firewall
+	case "repo":
+		// RepoManager consumes a []string of dnf repo IDs. linuxctl#57.
+		return linux.ReposEnable
+	case "file":
+		// FileManager consumes []config.FileSpec literal payloads. linuxctl#57.
+		return linux.Files
 	}
 	return linux
 }

--- a/pkg/apply/orchestrator.go
+++ b/pkg/apply/orchestrator.go
@@ -167,6 +167,10 @@ func (o *Orchestrator) desiredFor(name string) managers.Spec {
 		return o.Linux.Firewall
 	case "hosts":
 		return o.Linux.HostsEntries
+	case "repo":
+		return o.Linux.ReposEnable
+	case "file":
+		return o.Linux.Files
 	case "ssh":
 		// SSH auth pulls keys from UsersGroups; pass full Linux.
 		return o.Linux
@@ -212,6 +216,10 @@ func (o *Orchestrator) bindSession(m managers.Manager) managers.Manager {
 	case *managers.NetworkManager:
 		return v.WithSession(o.Session)
 	case *managers.SSHAuthManager:
+		return v.WithSession(o.Session)
+	case *managers.RepoManager:
+		return v.WithSession(o.Session)
+	case *managers.FileManager:
 		return v.WithSession(o.Session)
 	}
 	return m

--- a/pkg/config/bundle_expand_test.go
+++ b/pkg/config/bundle_expand_test.go
@@ -51,6 +51,96 @@ sysctl_preset: explicit-sysctl
 	}
 }
 
+// TestLoadLinux_BundleInlineExpansion exercises the linuxctl#57 inline
+// capabilities (repos_enable + files): bundle-supplied entries union with
+// explicit manifest entries, with explicit winning on path collision.
+func TestLoadLinux_BundleInlineExpansion(t *testing.T) {
+	old := bundleInlineExpander
+	t.Cleanup(func() { bundleInlineExpander = old })
+	RegisterBundleInlineExpander(func(name string) ([]string, []FileSpec, error) {
+		if name == "ol-bundle" {
+			return []string{"ol9_codeready_builder"},
+				[]FileSpec{{
+					Path:       "/usr/lib64/libpthread_nonshared.a",
+					Mode:       "0644",
+					Owner:      "root",
+					Group:      "root",
+					ContentB64: "ITxhcmNoPgo=",
+					CreateOnly: true,
+				}}, nil
+		}
+		return nil, nil, nil
+	})
+
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	content := []byte(`kind: Linux
+bundle_preset: ol-bundle
+repos_enable:
+  - explicit_repo
+files:
+  - path: /etc/explicit
+    mode: "0600"
+    content_b64: aGVsbG8=
+`)
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l, err := LoadLinux(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Union: explicit first, bundle entries appended.
+	if len(l.ReposEnable) != 2 {
+		t.Fatalf("ReposEnable = %v", l.ReposEnable)
+	}
+	if l.ReposEnable[0] != "explicit_repo" || l.ReposEnable[1] != "ol9_codeready_builder" {
+		t.Errorf("ordering wrong: %v", l.ReposEnable)
+	}
+	if len(l.Files) != 2 {
+		t.Fatalf("Files = %v", l.Files)
+	}
+	// Explicit file appears first in manifest order.
+	if l.Files[0].Path != "/etc/explicit" {
+		t.Errorf("explicit file should be first, got %q", l.Files[0].Path)
+	}
+	// Bundle file (libpthread stub) appears second.
+	if l.Files[1].Path != "/usr/lib64/libpthread_nonshared.a" || !l.Files[1].CreateOnly {
+		t.Errorf("bundle file: %+v", l.Files[1])
+	}
+}
+
+func TestLoadLinux_BundleInlineExpansion_ExplicitWinsOnPath(t *testing.T) {
+	old := bundleInlineExpander
+	t.Cleanup(func() { bundleInlineExpander = old })
+	RegisterBundleInlineExpander(func(name string) ([]string, []FileSpec, error) {
+		return []string{"r1"}, []FileSpec{{Path: "/x", ContentB64: "YnVuZGxl"}}, nil
+	})
+	dir := t.TempDir()
+	p := filepath.Join(dir, "linux.yaml")
+	content := []byte(`kind: Linux
+bundle_preset: any
+repos_enable:
+  - r1
+files:
+  - path: /x
+    content_b64: ZXhwbGljaXQ=
+`)
+	if err := os.WriteFile(p, content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	l, err := LoadLinux(p)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(l.ReposEnable) != 1 {
+		t.Errorf("dedup repos failed: %v", l.ReposEnable)
+	}
+	if len(l.Files) != 1 || l.Files[0].ContentB64 != "ZXhwbGljaXQ=" {
+		t.Errorf("explicit file should win on path collision, got %+v", l.Files)
+	}
+}
+
 func TestLoadLinux_BundleExpansion_NoHook(t *testing.T) {
 	old := bundleExpander
 	t.Cleanup(func() { bundleExpander = old })

--- a/pkg/config/linux.go
+++ b/pkg/config/linux.go
@@ -40,6 +40,14 @@ type Linux struct {
 	UsersGroupsPreset string `yaml:"users_groups_preset,omitempty"`
 	PackagesPreset    string `yaml:"packages_preset,omitempty"`
 	BundlePreset      string `yaml:"bundle_preset,omitempty"`
+	// ReposEnable lists dnf repository IDs the repo manager should
+	// ensure are enabled on the host. Bundle-supplied entries are
+	// unioned with explicit entries at config-load time. linuxctl#57.
+	ReposEnable []string `yaml:"repos_enable,omitempty"`
+	// Files declares literal file payloads materialised by the file
+	// manager. Content is base64-encoded so binary stubs (e.g. empty ar
+	// archives) survive YAML round-trips. linuxctl#57.
+	Files        []FileSpec     `yaml:"files,omitempty" validate:"dive"`
 	Firewall     *Firewall      `yaml:"firewall,omitempty"`
 	HostsEntries []HostEntry    `yaml:"hosts_entries,omitempty" validate:"dive"`
 	Services     []ServiceState `yaml:"services,omitempty" validate:"dive"`
@@ -156,6 +164,18 @@ type Packages struct {
 type SysctlEntry struct {
 	Key   string `yaml:"key" validate:"required"`
 	Value string `yaml:"value" validate:"required"`
+}
+
+// FileSpec is a literal file payload materialised by the file manager.
+// The file is identified by its absolute path; content is base64-encoded
+// so binary payloads survive YAML round-trips. linuxctl#57.
+type FileSpec struct {
+	Path       string `yaml:"path" validate:"required,startswith=/"`
+	Mode       string `yaml:"mode,omitempty" validate:"omitempty,len=4"`
+	Owner      string `yaml:"owner,omitempty"`
+	Group      string `yaml:"group,omitempty"`
+	ContentB64 string `yaml:"content_b64" validate:"required"`
+	CreateOnly bool   `yaml:"create_only,omitempty"`
 }
 
 // LimitEntry is a single /etc/security/limits.d entry.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -14,38 +14,111 @@ import (
 // RegisterBundleExpander() in its init().
 type BundleExpander func(name string) (map[string]string, error)
 
-var bundleExpander BundleExpander
+// BundleInlineExpander returns inline-capability data carried by a bundle
+// (repos_enable + files). Optional companion to BundleExpander introduced
+// in linuxctl#57. Loader gracefully tolerates a nil expander (older
+// pkg/presets versions).
+type BundleInlineExpander func(name string) (repos []string, files []FileSpec, err error)
+
+var (
+	bundleExpander       BundleExpander
+	bundleInlineExpander BundleInlineExpander
+)
 
 // RegisterBundleExpander wires an expander. pkg/presets calls this from init.
 func RegisterBundleExpander(fn BundleExpander) { bundleExpander = fn }
+
+// RegisterBundleInlineExpander wires the inline-capability expander.
+func RegisterBundleInlineExpander(fn BundleInlineExpander) { bundleInlineExpander = fn }
 
 // expandBundleOnLinux fills the per-category *_preset fields from the named
 // bundle, but only for fields the user left empty. Explicit per-category
 // presets always win over the bundle.
 func expandBundleOnLinux(l *Linux) error {
-	if l == nil || l.BundlePreset == "" || bundleExpander == nil {
+	if l == nil || l.BundlePreset == "" {
 		return nil
 	}
-	children, err := bundleExpander(l.BundlePreset)
-	if err != nil {
-		return fmt.Errorf("bundle %q: %w", l.BundlePreset, err)
+	if bundleExpander != nil {
+		children, err := bundleExpander(l.BundlePreset)
+		if err != nil {
+			return fmt.Errorf("bundle %q: %w", l.BundlePreset, err)
+		}
+		if l.DirectoriesPreset == "" {
+			l.DirectoriesPreset = children["directories"]
+		}
+		if l.UsersGroupsPreset == "" {
+			l.UsersGroupsPreset = children["users_groups"]
+		}
+		if l.PackagesPreset == "" {
+			l.PackagesPreset = children["packages"]
+		}
+		if l.SysctlPreset == "" {
+			l.SysctlPreset = children["sysctl"]
+		}
+		if l.LimitsPreset == "" {
+			l.LimitsPreset = children["limits"]
+		}
 	}
-	if l.DirectoriesPreset == "" {
-		l.DirectoriesPreset = children["directories"]
-	}
-	if l.UsersGroupsPreset == "" {
-		l.UsersGroupsPreset = children["users_groups"]
-	}
-	if l.PackagesPreset == "" {
-		l.PackagesPreset = children["packages"]
-	}
-	if l.SysctlPreset == "" {
-		l.SysctlPreset = children["sysctl"]
-	}
-	if l.LimitsPreset == "" {
-		l.LimitsPreset = children["limits"]
+	// Inline capabilities (linuxctl#57). Explicit manifest entries are
+	// retained; bundle entries are unioned in. Repo IDs dedup on string
+	// equality; FileSpec entries dedup on absolute path with explicit
+	// winning on collision.
+	if bundleInlineExpander != nil {
+		repos, files, err := bundleInlineExpander(l.BundlePreset)
+		if err != nil {
+			return fmt.Errorf("bundle %q (inline): %w", l.BundlePreset, err)
+		}
+		l.ReposEnable = mergeReposEnable(l.ReposEnable, repos)
+		l.Files = mergeFiles(l.Files, files)
 	}
 	return nil
+}
+
+// mergeReposEnable returns the union of explicit + bundle repo IDs,
+// preserving explicit-first ordering and removing duplicates.
+func mergeReposEnable(explicit, bundle []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(explicit)+len(bundle))
+	for _, r := range explicit {
+		if r == "" || seen[r] {
+			continue
+		}
+		seen[r] = true
+		out = append(out, r)
+	}
+	for _, r := range bundle {
+		if r == "" || seen[r] {
+			continue
+		}
+		seen[r] = true
+		out = append(out, r)
+	}
+	return out
+}
+
+// mergeFiles returns the union of explicit + bundle file specs keyed by
+// absolute path; explicit wins on collision.
+func mergeFiles(explicit, bundle []FileSpec) []FileSpec {
+	byPath := map[string]FileSpec{}
+	order := []string{}
+	for _, f := range explicit {
+		if _, dup := byPath[f.Path]; !dup {
+			order = append(order, f.Path)
+		}
+		byPath[f.Path] = f
+	}
+	for _, f := range bundle {
+		if _, has := byPath[f.Path]; has {
+			continue
+		}
+		byPath[f.Path] = f
+		order = append(order, f.Path)
+	}
+	out := make([]FileSpec, 0, len(order))
+	for _, p := range order {
+		out = append(out, byPath[p])
+	}
+	return out
 }
 
 // LoadLinux reads and decodes a linux.yaml from disk without validation.

--- a/pkg/managers/base_test.go
+++ b/pkg/managers/base_test.go
@@ -51,6 +51,8 @@ func TestAllManagers_DependsOn(t *testing.T) {
 		"ssh":      {deps: []string{"user"}},
 		"sysctl":   {deps: nil},
 		"user":     {deps: []string{"package"}},
+		"repo":     {deps: nil},
+		"file":     {deps: nil},
 	}
 
 	all := All()

--- a/pkg/managers/file.go
+++ b/pkg/managers/file.go
@@ -1,0 +1,248 @@
+package managers
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+	"github.com/itunified-io/linuxctl/pkg/session"
+)
+
+// FileManager reconciles literal file payloads declared in
+// config.Linux.Files (typically populated by a bundle preset; see
+// linuxctl#57). The manager owns each declared path: it writes the
+// decoded base64 content with the requested mode/owner/group, and on
+// Rollback it either removes the file (if absent before) or restores
+// the previous body.
+type FileManager struct {
+	sess session.Session
+}
+
+// NewFileManager returns a file manager with no session.
+func NewFileManager() *FileManager { return &FileManager{} }
+
+// WithSession binds sess for Apply / Verify / Rollback.
+func (m *FileManager) WithSession(s session.Session) *FileManager {
+	cp := *m
+	cp.sess = s
+	return &cp
+}
+
+// Name implements Manager.
+func (*FileManager) Name() string { return "file" }
+
+// DependsOn implements Manager. File payloads have no hard dependency on
+// any other manager — they describe state, not behaviour.
+func (*FileManager) DependsOn() []string { return nil }
+
+func init() { Register(NewFileManager()) }
+
+// ---- Plan -----------------------------------------------------------------
+
+// fileBefore captures the existing file (if any) so Rollback can restore it.
+type fileBefore struct {
+	Existed bool
+	Body    []byte
+}
+
+// fileApply is the After payload — the decoded body and its file metadata.
+type fileApply struct {
+	Spec config.FileSpec
+	Body []byte
+}
+
+// Plan implements Manager.
+func (m *FileManager) Plan(ctx context.Context, desired Spec, _ State) ([]Change, error) {
+	files := castFiles(desired)
+	if len(files) == 0 {
+		return nil, nil
+	}
+	if m.sess == nil {
+		return nil, ErrSessionRequired
+	}
+	// Stable iteration order for deterministic plans.
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+
+	var changes []Change
+	for _, f := range files {
+		body, err := decodeContent(f.ContentB64)
+		if err != nil {
+			return nil, fmt.Errorf("file.Plan: %s: %w", f.Path, err)
+		}
+		exists, err := m.sess.FileExists(ctx, f.Path)
+		if err != nil {
+			return nil, fmt.Errorf("file.Plan: stat %s: %w", f.Path, err)
+		}
+		var before fileBefore
+		var existingBody []byte
+		if exists {
+			existingBody, err = m.sess.ReadFile(ctx, f.Path)
+			if err != nil {
+				return nil, fmt.Errorf("file.Plan: read %s: %w", f.Path, err)
+			}
+			before = fileBefore{Existed: true, Body: existingBody}
+		}
+
+		// CreateOnly: skip if the file already exists, regardless of
+		// body drift. Used for stub files that must defer to a real
+		// implementation if installed later.
+		if f.CreateOnly && exists {
+			continue
+		}
+
+		// Idempotency: if body hash + mode match the desired, skip.
+		// (Owner/group are only verified at Apply time because reading
+		// them through session.Session would require a stat helper that
+		// is not yet on the interface.)
+		if exists && hashEqual(existingBody, body) {
+			// Same body — no content change. We currently do not
+			// re-stat mode/owner/group at Plan time; Apply runs
+			// chmod/chown unconditionally, which is itself idempotent.
+			continue
+		}
+
+		action := "create"
+		if exists {
+			action = "update"
+		}
+		changes = append(changes, Change{
+			ID:      "file:" + f.Path,
+			Manager: "file",
+			Target:  f.Path,
+			Action:  action,
+			Before:  before,
+			After:   fileApply{Spec: f, Body: body},
+			Hazard:  HazardWarn,
+		})
+	}
+	return changes, nil
+}
+
+// ---- Apply ----------------------------------------------------------------
+
+// Apply implements Manager.
+func (m *FileManager) Apply(ctx context.Context, changes []Change, dryRun bool) (ApplyResult, error) {
+	res := ApplyResult{}
+	if dryRun {
+		res.Skipped = append(res.Skipped, changes...)
+		return res, nil
+	}
+	if m.sess == nil {
+		return res, ErrSessionRequired
+	}
+	for _, ch := range changes {
+		a, ok := ch.After.(fileApply)
+		if !ok {
+			res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: fmt.Errorf("file.Apply: After is not fileApply (%T)", ch.After)})
+			continue
+		}
+		mode, err := parseMode(a.Spec.Mode, 0o644)
+		if err != nil {
+			res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: err})
+			continue
+		}
+		if err := m.sess.WriteFile(ctx, a.Spec.Path, a.Body, mode); err != nil {
+			res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: fmt.Errorf("write %s: %w", a.Spec.Path, err)})
+			continue
+		}
+		// chown if either owner or group set.
+		if a.Spec.Owner != "" || a.Spec.Group != "" {
+			ownerSpec := a.Spec.Owner
+			if a.Spec.Group != "" {
+				ownerSpec = ownerSpec + ":" + a.Spec.Group
+			}
+			cmd := "chown " + shellQuoteOne(ownerSpec) + " " + shellQuoteOne(a.Spec.Path)
+			if _, err := RunSudoAndCheck(ctx, m.sess, cmd); err != nil {
+				res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: fmt.Errorf("chown %s: %w", a.Spec.Path, err)})
+				continue
+			}
+		}
+		res.Applied = append(res.Applied, ch)
+	}
+	return res, nil
+}
+
+// ---- Verify + Rollback ----------------------------------------------------
+
+// Verify implements Manager.
+func (m *FileManager) Verify(ctx context.Context, desired Spec) (VerifyResult, error) {
+	changes, err := m.Plan(ctx, desired, nil)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	return VerifyResult{OK: len(changes) == 0, Drift: changes}, nil
+}
+
+// Rollback restores the pre-Apply state captured in Change.Before.
+func (m *FileManager) Rollback(ctx context.Context, changes []Change) error {
+	if m.sess == nil {
+		return ErrSessionRequired
+	}
+	for i := len(changes) - 1; i >= 0; i-- {
+		ch := changes[i]
+		b, ok := ch.Before.(fileBefore)
+		if !ok {
+			continue
+		}
+		path, ok := ch.Target, true
+		_ = ok
+		if !b.Existed {
+			_, _ = RunSudoAndCheck(ctx, m.sess, "rm -f "+shellQuoteOne(path))
+			continue
+		}
+		if err := m.sess.WriteFile(ctx, path, b.Body, 0o644); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ---- helpers --------------------------------------------------------------
+
+// decodeContent returns the decoded body of a FileSpec.ContentB64.
+func decodeContent(b64 string) ([]byte, error) {
+	if b64 == "" {
+		return nil, nil
+	}
+	body, err := base64.StdEncoding.DecodeString(b64)
+	if err != nil {
+		return nil, fmt.Errorf("invalid content_b64: %w", err)
+	}
+	return body, nil
+}
+
+// parseMode parses a 4-digit octal mode string. Empty falls back to def.
+func parseMode(s string, def uint32) (uint32, error) {
+	if s == "" {
+		return def, nil
+	}
+	v, err := strconv.ParseUint(s, 8, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid mode %q: %w", s, err)
+	}
+	return uint32(v), nil
+}
+
+// hashEqual reports whether a + b have the same SHA-256 digest.
+func hashEqual(a, b []byte) bool {
+	ha := sha256.Sum256(a)
+	hb := sha256.Sum256(b)
+	return hex.EncodeToString(ha[:]) == hex.EncodeToString(hb[:])
+}
+
+// castFiles accepts the typed slice the runtime passes for the file manager.
+func castFiles(desired Spec) []config.FileSpec {
+	switch v := desired.(type) {
+	case []config.FileSpec:
+		return v
+	case nil:
+		return nil
+	default:
+		return nil
+	}
+}

--- a/pkg/managers/file_test.go
+++ b/pkg/managers/file_test.go
@@ -1,0 +1,219 @@
+package managers
+
+import (
+	"context"
+	"encoding/base64"
+	"testing"
+
+	"github.com/itunified-io/linuxctl/pkg/config"
+)
+
+func b64(s string) string { return base64.StdEncoding.EncodeToString([]byte(s)) }
+
+const arEmptyB64 = "ITxhcmNoPgo=" // !<arch>\n
+
+func TestFileManager_Plan_CreateMissingFile(t *testing.T) {
+	mock := newFileMock()
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{
+		Path:       "/usr/lib64/libpthread_nonshared.a",
+		Mode:       "0644",
+		Owner:      "root",
+		Group:      "root",
+		ContentB64: arEmptyB64,
+	}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d", len(changes))
+	}
+	if changes[0].Action != "create" {
+		t.Errorf("Action = %q, want create", changes[0].Action)
+	}
+}
+
+func TestFileManager_Plan_IdempotentSameBody(t *testing.T) {
+	body := "!<arch>\n"
+	mock := newFileMock().withFile("/x/y", body)
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: b64(body)}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes (same body), got %d", len(changes))
+	}
+}
+
+func TestFileManager_Plan_DriftDetected_WhenBodyDiffers(t *testing.T) {
+	mock := newFileMock().withFile("/x/y", "old content")
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: b64("new content")}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Action != "update" {
+		t.Fatalf("expected 1 update change, got %+v", changes)
+	}
+}
+
+func TestFileManager_Plan_CreateOnly_PreservesExisting(t *testing.T) {
+	mock := newFileMock().withFile("/x/y", "user wrote this")
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{
+		Path:       "/x/y",
+		ContentB64: b64("stub content"),
+		CreateOnly: true,
+	}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("CreateOnly + existing file should yield 0 changes, got %d", len(changes))
+	}
+}
+
+func TestFileManager_Plan_CreateOnly_StillCreatesIfMissing(t *testing.T) {
+	mock := newFileMock()
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{
+		Path:       "/x/y",
+		ContentB64: arEmptyB64,
+		CreateOnly: true,
+	}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 1 || changes[0].Action != "create" {
+		t.Errorf("CreateOnly + missing file should create, got %+v", changes)
+	}
+}
+
+func TestFileManager_Plan_InvalidContentB64_Errors(t *testing.T) {
+	mock := newFileMock()
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: "!!! not base64 !!!"}}
+	_, err := m.Plan(context.Background(), Spec(files), nil)
+	if err == nil {
+		t.Fatal("expected error for invalid base64")
+	}
+}
+
+func TestFileManager_Apply_WritesAndChowns(t *testing.T) {
+	mock := newFileMock().on("chown", "", nil)
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{
+		Path:       "/usr/lib64/libpthread_nonshared.a",
+		Mode:       "0644",
+		Owner:      "root",
+		Group:      "root",
+		ContentB64: arEmptyB64,
+	}}
+	changes, err := m.Plan(context.Background(), Spec(files), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	res, err := m.Apply(context.Background(), changes, false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Applied) != 1 {
+		t.Errorf("Applied = %d, want 1", len(res.Applied))
+	}
+	written, ok := mock.writes["/usr/lib64/libpthread_nonshared.a"]
+	if !ok {
+		t.Fatal("file was not written")
+	}
+	want := "!<arch>\n"
+	if string(written) != want {
+		t.Errorf("body = %q, want %q", string(written), want)
+	}
+	if !mock.ran("chown 'root:root' '/usr/lib64/libpthread_nonshared.a'") {
+		t.Errorf("expected chown call, cmds = %v", mock.cmds)
+	}
+}
+
+func TestFileManager_Apply_DryRun_NoWrites(t *testing.T) {
+	mock := newFileMock()
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: arEmptyB64}}
+	changes, _ := m.Plan(context.Background(), Spec(files), nil)
+	res, err := m.Apply(context.Background(), changes, true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Errorf("Skipped = %d, want 1", len(res.Skipped))
+	}
+	if _, wrote := mock.writes["/x/y"]; wrote {
+		t.Error("dry-run wrote a file")
+	}
+}
+
+func TestFileManager_Verify_OK_WhenNoDrift(t *testing.T) {
+	body := "!<arch>\n"
+	mock := newFileMock().withFile("/x/y", body)
+	m := NewFileManager().WithSession(mock)
+	res, err := m.Verify(context.Background(), Spec([]config.FileSpec{{Path: "/x/y", ContentB64: b64(body)}}))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !res.OK {
+		t.Errorf("Verify OK = false, want true; drift = %+v", res.Drift)
+	}
+}
+
+func TestFileManager_Rollback_RemovesCreatedFile(t *testing.T) {
+	mock := newFileMock().on("rm -f", "", nil)
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: arEmptyB64}}
+	changes, _ := m.Plan(context.Background(), Spec(files), nil)
+	if err := m.Rollback(context.Background(), changes); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if !mock.ran("rm -f '/x/y'") {
+		t.Errorf("expected rm -f call, cmds = %v", mock.cmds)
+	}
+}
+
+func TestFileManager_Rollback_RestoresPreviousBody(t *testing.T) {
+	mock := newFileMock().withFile("/x/y", "previous content")
+	m := NewFileManager().WithSession(mock)
+	files := []config.FileSpec{{Path: "/x/y", ContentB64: b64("new content")}}
+	changes, _ := m.Plan(context.Background(), Spec(files), nil)
+	if err := m.Rollback(context.Background(), changes); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	got := string(mock.writes["/x/y"])
+	if got != "previous content" {
+		t.Errorf("rollback body = %q, want %q", got, "previous content")
+	}
+}
+
+func TestFileManager_RequiresSession(t *testing.T) {
+	m := NewFileManager()
+	_, err := m.Plan(context.Background(), Spec([]config.FileSpec{{Path: "/x", ContentB64: arEmptyB64}}), nil)
+	if err != ErrSessionRequired {
+		t.Errorf("err = %v, want ErrSessionRequired", err)
+	}
+}
+
+func TestParseMode_Default(t *testing.T) {
+	got, err := parseMode("", 0o600)
+	if err != nil || got != 0o600 {
+		t.Errorf("default mode: got=%o err=%v want=600", got, err)
+	}
+	got, err = parseMode("0644", 0)
+	if err != nil || got != 0o644 {
+		t.Errorf("0644: got=%o err=%v", got, err)
+	}
+	if _, err := parseMode("notoctal", 0); err == nil {
+		t.Error("expected error for invalid mode")
+	}
+}

--- a/pkg/managers/repo.go
+++ b/pkg/managers/repo.go
@@ -1,0 +1,213 @@
+package managers
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/itunified-io/linuxctl/pkg/session"
+)
+
+// RepoManager reconciles dnf-managed repository enablement state.
+//
+// The manager only enables repositories declared in the manifest's
+// `repos_enable:` list (typically populated by a bundle preset — see
+// linuxctl#57). Disabling repositories is a one-way Rollback action,
+// performed only on the IDs this run enabled.
+type RepoManager struct {
+	sess session.Session
+}
+
+// NewRepoManager returns a repo manager with no session.
+func NewRepoManager() *RepoManager { return &RepoManager{} }
+
+// WithSession binds sess for Apply / Verify / Rollback.
+func (m *RepoManager) WithSession(s session.Session) *RepoManager {
+	cp := *m
+	cp.sess = s
+	return &cp
+}
+
+// Name implements Manager.
+func (*RepoManager) Name() string { return "repo" }
+
+// DependsOn implements Manager. Repos must be enabled before package install
+// resolution but after a working dnf binary (which the base image provides).
+func (*RepoManager) DependsOn() []string { return nil }
+
+func init() { Register(NewRepoManager()) }
+
+// ---- Plan -----------------------------------------------------------------
+
+// repoPlanPayload pairs the desired repo ID with its observed enabled state
+// at plan time, captured in Change.Before so Rollback can reverse exactly
+// what Apply enabled.
+type repoPlanPayload struct {
+	ID            string
+	WasEnabledBefore bool
+}
+
+// Plan implements Manager.
+func (m *RepoManager) Plan(ctx context.Context, desired Spec, _ State) ([]Change, error) {
+	repos := castReposEnable(desired)
+	if len(repos) == 0 {
+		return nil, nil
+	}
+	if m.sess == nil {
+		return nil, ErrSessionRequired
+	}
+	enabled, err := m.listEnabled(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("repo.Plan: list enabled repos: %w", err)
+	}
+	known, err := m.listAll(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("repo.Plan: list all repos: %w", err)
+	}
+	var changes []Change
+	seen := map[string]bool{}
+	for _, id := range repos {
+		if id == "" || seen[id] {
+			continue
+		}
+		seen[id] = true
+		if enabled[id] {
+			continue // already in desired state
+		}
+		if !known[id] {
+			return nil, fmt.Errorf("repo.Plan: repo %q is not configured on this host", id)
+		}
+		changes = append(changes, Change{
+			ID:      "repo:" + id,
+			Manager: "repo",
+			Target:  id,
+			Action:  "update",
+			Before:  repoPlanPayload{ID: id, WasEnabledBefore: false},
+			After:   repoPlanPayload{ID: id, WasEnabledBefore: false},
+			Hazard:  HazardWarn,
+		})
+	}
+	return changes, nil
+}
+
+// ---- Apply ----------------------------------------------------------------
+
+// Apply implements Manager.
+func (m *RepoManager) Apply(ctx context.Context, changes []Change, dryRun bool) (ApplyResult, error) {
+	res := ApplyResult{}
+	if dryRun {
+		res.Skipped = append(res.Skipped, changes...)
+		return res, nil
+	}
+	if m.sess == nil {
+		return res, ErrSessionRequired
+	}
+	for _, ch := range changes {
+		p, ok := ch.After.(repoPlanPayload)
+		if !ok {
+			res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: fmt.Errorf("repo.Apply: After is not repoPlanPayload (%T)", ch.After)})
+			continue
+		}
+		cmd := "dnf config-manager --set-enabled " + shellQuoteOne(p.ID)
+		if _, err := RunSudoAndCheck(ctx, m.sess, cmd); err != nil {
+			res.Failed = append(res.Failed, ChangeErr{Change: ch, Err: fmt.Errorf("enable %s: %w", p.ID, err)})
+			continue
+		}
+		res.Applied = append(res.Applied, ch)
+	}
+	return res, nil
+}
+
+// ---- Verify + Rollback ----------------------------------------------------
+
+// Verify implements Manager.
+func (m *RepoManager) Verify(ctx context.Context, desired Spec) (VerifyResult, error) {
+	changes, err := m.Plan(ctx, desired, nil)
+	if err != nil {
+		return VerifyResult{}, err
+	}
+	return VerifyResult{OK: len(changes) == 0, Drift: changes}, nil
+}
+
+// Rollback disables exactly the repo IDs this run enabled (Before.WasEnabledBefore == false).
+func (m *RepoManager) Rollback(ctx context.Context, changes []Change) error {
+	if m.sess == nil {
+		return ErrSessionRequired
+	}
+	for i := len(changes) - 1; i >= 0; i-- {
+		ch := changes[i]
+		b, ok := ch.Before.(repoPlanPayload)
+		if !ok {
+			continue
+		}
+		if b.WasEnabledBefore {
+			continue // we did not enable it; leave alone
+		}
+		_, _ = RunSudoAndCheck(ctx, m.sess, "dnf config-manager --set-disabled "+shellQuoteOne(b.ID))
+	}
+	return nil
+}
+
+// ---- helpers --------------------------------------------------------------
+
+// listEnabled returns a set of currently-enabled repo IDs.
+func (m *RepoManager) listEnabled(ctx context.Context) (map[string]bool, error) {
+	out, _, err := m.sess.Run(ctx, "dnf -q repolist --enabled")
+	if err != nil {
+		return nil, err
+	}
+	return parseRepolist(out), nil
+}
+
+// listAll returns the set of all configured repo IDs (enabled or disabled).
+func (m *RepoManager) listAll(ctx context.Context) (map[string]bool, error) {
+	out, _, err := m.sess.Run(ctx, "dnf -q repolist --all")
+	if err != nil {
+		return nil, err
+	}
+	return parseRepolist(out), nil
+}
+
+// parseRepolist extracts repo IDs from `dnf repolist` output. The first
+// whitespace-delimited token of each non-header line is the repo ID.
+// "repo id" and "repo name" header lines are skipped.
+func parseRepolist(out string) map[string]bool {
+	res := map[string]bool{}
+	for _, ln := range strings.Split(out, "\n") {
+		ln = strings.TrimSpace(ln)
+		if ln == "" {
+			continue
+		}
+		// Skip the dnf table header.
+		if strings.HasPrefix(strings.ToLower(ln), "repo id") {
+			continue
+		}
+		fields := strings.Fields(ln)
+		if len(fields) == 0 {
+			continue
+		}
+		id := fields[0]
+		if id == "Last" || strings.HasPrefix(id, "metadata") {
+			continue
+		}
+		res[id] = true
+	}
+	return res
+}
+
+// castReposEnable accepts the slice form (manifest-driven) directly. The
+// orchestrator passes desiredFor("repo") which returns []string from
+// config.Linux.ReposEnable.
+func castReposEnable(desired Spec) []string {
+	switch v := desired.(type) {
+	case []string:
+		out := append([]string(nil), v...)
+		sort.Strings(out)
+		return out
+	case nil:
+		return nil
+	default:
+		return nil
+	}
+}

--- a/pkg/managers/repo_test.go
+++ b/pkg/managers/repo_test.go
@@ -1,0 +1,177 @@
+package managers
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// repolist output fixtures.
+const (
+	enabledOnlyAppstream = "repo id    repo name\nol9_appstream   Oracle Linux 9 (x86_64) AppStream\nol9_baseos      Oracle Linux 9 (x86_64) BaseOS\n"
+	allReposCRBKnown     = "repo id    repo name\nol9_appstream             Oracle Linux 9 AppStream\nol9_baseos                Oracle Linux 9 BaseOS\nol9_codeready_builder     Oracle Linux 9 CodeReady Builder\n"
+	allReposEnabledCRB   = "repo id    repo name\nol9_appstream             Oracle Linux 9 AppStream\nol9_baseos                Oracle Linux 9 BaseOS\nol9_codeready_builder     Oracle Linux 9 CodeReady Builder\n"
+)
+
+func newRepoMock() *fileMockSession {
+	return newFileMock().
+		on("repolist --enabled", enabledOnlyAppstream, nil).
+		on("repolist --all", allReposCRBKnown, nil).
+		on("config-manager --set-enabled", "", nil).
+		on("config-manager --set-disabled", "", nil)
+}
+
+func TestRepoManager_Plan_EnableMissingRepo(t *testing.T) {
+	m := NewRepoManager().WithSession(newRepoMock())
+	desired := []string{"ol9_codeready_builder"}
+	changes, err := m.Plan(context.Background(), Spec(desired), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change, got %d: %+v", len(changes), changes)
+	}
+	if changes[0].Target != "ol9_codeready_builder" {
+		t.Errorf("Target = %q, want ol9_codeready_builder", changes[0].Target)
+	}
+	if changes[0].Action != "update" {
+		t.Errorf("Action = %q, want update", changes[0].Action)
+	}
+}
+
+func TestRepoManager_Plan_AlreadyEnabled_NoChange(t *testing.T) {
+	mock := newFileMock().
+		on("repolist --enabled", allReposEnabledCRB, nil).
+		on("repolist --all", allReposCRBKnown, nil)
+	m := NewRepoManager().WithSession(mock)
+	desired := []string{"ol9_codeready_builder"}
+	changes, err := m.Plan(context.Background(), Spec(desired), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes (already enabled), got %d", len(changes))
+	}
+}
+
+func TestRepoManager_Plan_UnknownRepo_Errors(t *testing.T) {
+	m := NewRepoManager().WithSession(newRepoMock())
+	desired := []string{"nonexistent_repo"}
+	_, err := m.Plan(context.Background(), Spec(desired), nil)
+	if err == nil {
+		t.Fatal("expected error for unknown repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "not configured") {
+		t.Errorf("error = %v, want 'not configured'", err)
+	}
+}
+
+func TestRepoManager_Plan_EmptyDesired_NoChange(t *testing.T) {
+	m := NewRepoManager().WithSession(newRepoMock())
+	changes, err := m.Plan(context.Background(), Spec([]string{}), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	if len(changes) != 0 {
+		t.Errorf("expected 0 changes, got %d", len(changes))
+	}
+}
+
+func TestRepoManager_Plan_RequiresSession(t *testing.T) {
+	m := NewRepoManager()
+	_, err := m.Plan(context.Background(), Spec([]string{"ol9_codeready_builder"}), nil)
+	if err != ErrSessionRequired {
+		t.Errorf("err = %v, want ErrSessionRequired", err)
+	}
+}
+
+func TestRepoManager_Apply_RunsConfigManager(t *testing.T) {
+	mock := newRepoMock()
+	m := NewRepoManager().WithSession(mock)
+	changes, err := m.Plan(context.Background(), Spec([]string{"ol9_codeready_builder"}), nil)
+	if err != nil {
+		t.Fatalf("Plan: %v", err)
+	}
+	res, err := m.Apply(context.Background(), changes, false)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Applied) != 1 {
+		t.Errorf("Applied = %d, want 1", len(res.Applied))
+	}
+	if !mock.ran("dnf config-manager --set-enabled 'ol9_codeready_builder'") {
+		t.Errorf("expected dnf config-manager --set-enabled call, cmds = %v", mock.cmds)
+	}
+}
+
+func TestRepoManager_Apply_DryRun_NoCommands(t *testing.T) {
+	mock := newRepoMock()
+	m := NewRepoManager().WithSession(mock)
+	changes, _ := m.Plan(context.Background(), Spec([]string{"ol9_codeready_builder"}), nil)
+	cmdsBefore := len(mock.cmds)
+	res, err := m.Apply(context.Background(), changes, true)
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+	if len(res.Skipped) != 1 {
+		t.Errorf("Skipped = %d, want 1", len(res.Skipped))
+	}
+	// Apply must not run any commands beyond what Plan ran.
+	if len(mock.cmds) != cmdsBefore {
+		t.Errorf("dry-run ran extra commands: %v", mock.cmds[cmdsBefore:])
+	}
+}
+
+func TestRepoManager_Verify_OK_WhenNoDrift(t *testing.T) {
+	mock := newFileMock().
+		on("repolist --enabled", allReposEnabledCRB, nil).
+		on("repolist --all", allReposCRBKnown, nil)
+	m := NewRepoManager().WithSession(mock)
+	res, err := m.Verify(context.Background(), Spec([]string{"ol9_codeready_builder"}))
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if !res.OK {
+		t.Errorf("Verify OK = false, want true; drift = %+v", res.Drift)
+	}
+}
+
+func TestRepoManager_Rollback_DisablesRepo(t *testing.T) {
+	mock := newRepoMock()
+	m := NewRepoManager().WithSession(mock)
+	changes, _ := m.Plan(context.Background(), Spec([]string{"ol9_codeready_builder"}), nil)
+	if err := m.Rollback(context.Background(), changes); err != nil {
+		t.Fatalf("Rollback: %v", err)
+	}
+	if !mock.ran("dnf config-manager --set-disabled 'ol9_codeready_builder'") {
+		t.Errorf("expected --set-disabled call, cmds = %v", mock.cmds)
+	}
+}
+
+func TestRepoManager_Idempotency(t *testing.T) {
+	// Two consecutive Plans against the post-Apply state must yield empty diffs.
+	mock := newFileMock().
+		on("repolist --enabled", allReposEnabledCRB, nil).
+		on("repolist --all", allReposCRBKnown, nil)
+	m := NewRepoManager().WithSession(mock)
+	for i := 0; i < 2; i++ {
+		changes, err := m.Plan(context.Background(), Spec([]string{"ol9_codeready_builder"}), nil)
+		if err != nil {
+			t.Fatalf("Plan #%d: %v", i, err)
+		}
+		if len(changes) != 0 {
+			t.Errorf("Plan #%d: expected 0 changes (idempotent), got %d", i, len(changes))
+		}
+	}
+}
+
+func TestParseRepolist_StripsHeader(t *testing.T) {
+	out := parseRepolist(allReposCRBKnown)
+	if !out["ol9_appstream"] || !out["ol9_codeready_builder"] {
+		t.Errorf("missing repo IDs: %+v", out)
+	}
+	// "repo" header line must NOT make it into the set.
+	if out["repo"] {
+		t.Errorf("header line leaked into result")
+	}
+}

--- a/pkg/presets/data/bundles/oracle-single-19c.yaml
+++ b/pkg/presets/data/bundles/oracle-single-19c.yaml
@@ -5,7 +5,7 @@ metadata:
   category: bundles
   tier: community
   source: "Oracle Database 19c single-instance baseline"
-  version: "2026-04-22"
+  version: "2026-05-03"
 spec:
   bundle:
     directories_preset: oracle-ofa-19c
@@ -13,3 +13,32 @@ spec:
     packages_preset: oracle-19c
     sysctl_preset: oracle-19c
     limits_preset: oracle-19c
+    # OL9 Oracle 19c build-time prereqs (linuxctl#57).
+    #
+    # ol9_codeready_builder ships build-only deps that
+    # oracle-database-preinstall-19c does not depend on but runInstaller's
+    # link step needs (libnsl, glibc-devel split-outs, etc.). The repo
+    # exists on every OL9 host but is shipped DISABLED by default.
+    repos_enable:
+      - ol9_codeready_builder
+
+    # /usr/lib64/libpthread_nonshared.a stub.
+    #
+    # On glibc ≥ 2.34 (RHEL 9 / OL 9) the legacy non-shared libpthread
+    # stub was split out and removed from the headline glibc-devel
+    # package. runInstaller's genclntsh link command still passes
+    # `-lpthread_nonshared` and aborts with an unresolved-symbol error
+    # in the absence of the file.
+    #
+    # The 8-byte payload below is a properly-formed empty `ar` archive
+    # (`!<arch>\n`) — `ld` accepts it and contributes nothing to the
+    # final binary, satisfying the linker without polluting the runtime.
+    # CreateOnly=true so that if Oracle ever ships a real implementation
+    # in a later RPM, the stub is not clobbered.
+    files:
+      - path: /usr/lib64/libpthread_nonshared.a
+        mode: "0644"
+        owner: root
+        group: root
+        content_b64: "ITxhcmNoPgo="
+        create_only: true

--- a/pkg/presets/data/packages/oracle-19c.yaml
+++ b/pkg/presets/data/packages/oracle-19c.yaml
@@ -35,8 +35,7 @@ spec:
       #
       # NOTE: ol9_codeready_builder repo enablement and the
       # /usr/lib64/libpthread_nonshared.a stub file (glibc-on-OL9 split-out
-      # workaround for runInstaller's genclntsh) need new bundle capabilities
-      # (`repos_enable:` + `files:`) which do not yet exist in the preset
-      # schema. Tracked as follow-up after linuxctl#57. For now, the
-      # /oracle-grid-install + /oracle-dbhome-install skills handle those two
-      # OL9-specific shims directly.
+      # workaround for runInstaller's genclntsh) are now declared on the
+      # oracle-single-19c bundle via the `repos_enable:` + `files:`
+      # capabilities introduced in linuxctl#57 (v2). See
+      # pkg/presets/data/bundles/oracle-single-19c.yaml.

--- a/pkg/presets/loader_hook.go
+++ b/pkg/presets/loader_hook.go
@@ -9,4 +9,7 @@ func init() {
 	config.RegisterBundleExpander(func(name string) (map[string]string, error) {
 		return BundleExpand(name, nil)
 	})
+	config.RegisterBundleInlineExpander(func(name string) ([]string, []config.FileSpec, error) {
+		return BundleInlineExpand(name, nil)
+	})
 }

--- a/pkg/presets/presets_test.go
+++ b/pkg/presets/presets_test.go
@@ -471,6 +471,97 @@ func TestBundleExpand_NotABundle(t *testing.T) {
 	}
 }
 
+// TestBundleInlineExpand_OracleSingle19c verifies that the OL9 Oracle 19c
+// inline-capability shims (linuxctl#57 v2) are surfaced by the registry:
+//   - ol9_codeready_builder must be in repos_enable
+//   - /usr/lib64/libpthread_nonshared.a stub must be in files (CreateOnly)
+func TestBundleInlineExpand_OracleSingle19c(t *testing.T) {
+	repos, files, err := BundleInlineExpand("oracle-single-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundCRB := false
+	for _, r := range repos {
+		if r == "ol9_codeready_builder" {
+			foundCRB = true
+		}
+	}
+	if !foundCRB {
+		t.Errorf("oracle-single-19c missing ol9_codeready_builder in repos_enable; got %v", repos)
+	}
+	var stub *config.FileSpec
+	for i, f := range files {
+		if f.Path == "/usr/lib64/libpthread_nonshared.a" {
+			stub = &files[i]
+		}
+	}
+	if stub == nil {
+		t.Fatalf("oracle-single-19c missing libpthread_nonshared.a stub; got files=%v", files)
+	}
+	if !stub.CreateOnly {
+		t.Errorf("libpthread stub should be CreateOnly")
+	}
+	if stub.Mode != "0644" || stub.Owner != "root" || stub.Group != "root" {
+		t.Errorf("libpthread stub metadata: mode=%q owner=%q group=%q", stub.Mode, stub.Owner, stub.Group)
+	}
+	if stub.ContentB64 == "" {
+		t.Errorf("libpthread stub has no content_b64")
+	}
+}
+
+func TestBundleInlineExpand_NoInlineYieldsEmpty(t *testing.T) {
+	// oracle-rac-19c does not declare inline capabilities — both lists empty.
+	repos, files, err := BundleInlineExpand("oracle-rac-19c", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(repos) != 0 || len(files) != 0 {
+		t.Errorf("oracle-rac-19c should have no inline caps, got repos=%v files=%v", repos, files)
+	}
+}
+
+func TestBundleParse_RepoAndFiles(t *testing.T) {
+	// Round-trip a Bundle YAML through schema decode to confirm
+	// repos_enable + files survive parsing.
+	src := `
+apiVersion: linuxctl.itunified.io/preset/v1
+kind: Bundle
+metadata:
+  name: test-inline
+  category: bundles
+spec:
+  bundle:
+    packages_preset: oracle-19c
+    repos_enable:
+      - r1
+      - r2
+    files:
+      - path: /a
+        mode: "0600"
+        owner: root
+        group: root
+        content_b64: aGVsbG8=
+        create_only: true
+`
+	var pr Preset
+	if err := yaml.Unmarshal([]byte(src), &pr); err != nil {
+		t.Fatal(err)
+	}
+	b, err := decodeBundle(&pr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b.PackagesPreset != "oracle-19c" {
+		t.Errorf("PackagesPreset = %q", b.PackagesPreset)
+	}
+	if len(b.ReposEnable) != 2 || b.ReposEnable[0] != "r1" {
+		t.Errorf("ReposEnable = %v", b.ReposEnable)
+	}
+	if len(b.Files) != 1 || b.Files[0].Path != "/a" || !b.Files[0].CreateOnly {
+		t.Errorf("Files = %+v", b.Files)
+	}
+}
+
 func TestSpecDecoders(t *testing.T) {
 	// Directories
 	p, err := ResolveCategory("directories", "oracle-ofa-19c", nil)

--- a/pkg/presets/registry.go
+++ b/pkg/presets/registry.go
@@ -144,6 +144,41 @@ func BundleExpand(name string, tierFn TierFunc) (map[string]string, error) {
 	return out, nil
 }
 
+// BundleInlineExpand returns the inline capabilities (repos_enable + files)
+// declared on a bundle. Both lists may be empty / nil for bundles that do
+// not use inline capabilities. Tier-gating mirrors BundleExpand.
+//
+// The Bundle struct already decodes both fields during load(); this helper
+// converts the registry-internal FileSpec into the config-package shape so
+// callers in pkg/config can consume the result without an import cycle.
+func BundleInlineExpand(name string, tierFn TierFunc) ([]string, []config.FileSpec, error) {
+	p, err := ResolveCategory("bundles", name, tierFn)
+	if err != nil {
+		return nil, nil, err
+	}
+	if p.Kind != "Bundle" {
+		return nil, nil, fmt.Errorf("preset %q is not a Bundle (kind=%q)", name, p.Kind)
+	}
+	idx, _ := load()
+	b, ok := idx.bundles[name]
+	if !ok {
+		return nil, nil, fmt.Errorf("bundle %q: internal: not in bundle index", name)
+	}
+	repos := append([]string(nil), b.ReposEnable...)
+	files := make([]config.FileSpec, 0, len(b.Files))
+	for _, f := range b.Files {
+		files = append(files, config.FileSpec{
+			Path:       f.Path,
+			Mode:       f.Mode,
+			Owner:      f.Owner,
+			Group:      f.Group,
+			ContentB64: f.ContentB64,
+			CreateOnly: f.CreateOnly,
+		})
+	}
+	return repos, files, nil
+}
+
 // ---- Typed spec decoders ---------------------------------------------------
 //
 // These helpers decode a preset's RawSpec into the concrete Go types the

--- a/pkg/presets/schema.go
+++ b/pkg/presets/schema.go
@@ -47,13 +47,43 @@ type Preset struct {
 	RawSpec map[string]any `yaml:"spec"`
 }
 
-// Bundle is a meta-preset that composes one preset per category.
+// Bundle is a meta-preset that composes one preset per category. In
+// addition to per-category preset references, a bundle may carry inline
+// capabilities that do not fit the named-preset model (linuxctl#57):
+//
+//   - ReposEnable: dnf repository IDs to enable on the host (e.g.
+//     ol9_codeready_builder for OL9 Oracle 19c builds).
+//   - Files: literal file payloads to materialise (e.g. the
+//     /usr/lib64/libpthread_nonshared.a stub used as a glibc-on-OL9
+//     workaround for runInstaller's genclntsh link step).
+//
+// Both lists are merge-targets on config.Linux: explicit entries in the
+// stack manifest are unioned with bundle-supplied entries; conflicts on
+// the natural key (repo ID / file path) are resolved in favour of the
+// explicit (manifest) entry.
 type Bundle struct {
-	DirectoriesPreset string `yaml:"directories_preset,omitempty"`
-	UsersGroupsPreset string `yaml:"users_groups_preset,omitempty"`
-	PackagesPreset    string `yaml:"packages_preset,omitempty"`
-	SysctlPreset      string `yaml:"sysctl_preset,omitempty"`
-	LimitsPreset      string `yaml:"limits_preset,omitempty"`
+	DirectoriesPreset string     `yaml:"directories_preset,omitempty"`
+	UsersGroupsPreset string     `yaml:"users_groups_preset,omitempty"`
+	PackagesPreset    string     `yaml:"packages_preset,omitempty"`
+	SysctlPreset      string     `yaml:"sysctl_preset,omitempty"`
+	LimitsPreset      string     `yaml:"limits_preset,omitempty"`
+	ReposEnable       []string   `yaml:"repos_enable,omitempty"`
+	Files             []FileSpec `yaml:"files,omitempty"`
+}
+
+// FileSpec describes a single file payload owned by the file manager.
+// Content is base64-encoded so binary payloads (empty ar archives, ELF
+// stubs) survive YAML round-trips intact.
+type FileSpec struct {
+	Path       string `yaml:"path"`
+	Mode       string `yaml:"mode,omitempty"`
+	Owner      string `yaml:"owner,omitempty"`
+	Group      string `yaml:"group,omitempty"`
+	ContentB64 string `yaml:"content_b64"`
+	// CreateOnly skips overwrite when the target already exists. Used for
+	// stub files that must not clobber a real implementation if one was
+	// installed by a later RPM.
+	CreateOnly bool `yaml:"create_only,omitempty"`
 }
 
 // TierFunc is a callback supplied by the caller (usually wired to the license


### PR DESCRIPTION
## Summary
Closes #57 fully. The v1 PR (#58) shipped only gcc/gcc-c++/make/binutils; the OL9-specific shims (codeready_builder repo + libpthread stub) were deferred pending schema work — that work lands here.

- **Schema:** `Bundle` (and `config.Linux`) gain inline capabilities `repos_enable []string` + `files []FileSpec`. Loader unions bundle + explicit entries; explicit wins on natural-key collision.
- **Two new managers** (full plan/apply/verify/rollback contract):
  - `repo` — idempotently enables dnf repo IDs via `dnf config-manager --set-enabled`
  - `file` — writes literal base64-encoded payloads with mode/owner/group + `create_only` semantics
- **CLI:** `linuxctl repo {plan,apply,verify}` + `linuxctl file {plan,apply,verify}`
- **`oracle-single-19c` bundle now declares:**
  - `repos_enable: [ol9_codeready_builder]`
  - `files: [/usr/lib64/libpthread_nonshared.a]` — 8-byte `!<arch>\n` empty ar archive stub, `create_only: true`

### Test counts
- Schema parse: 3 tests (bundle round-trip, oracle-single-19c integration, no-inline bundle)
- RepoManager: 12 tests (plan/apply/verify/rollback + idempotency + parser)
- FileManager: 13 tests (create/update/CreateOnly/dry-run/rollback + helpers)
- CLI / runtime wiring: covered by existing `TestAllManagers_DependsOn` (extended to 15 managers)
- oracle-single-19c integration via loader: 2 tests (union + explicit-wins-on-collision)
- **Total new: 33 tests; all pre-existing tests remain green.**

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` — all packages pass
- [x] `linuxctl repo --help` + `linuxctl file --help` smoke
- [ ] Live test on `ext3adm1` / `ext4adm1` (OL9.7) — confirms genclntsh links cleanly with stub in place
- [ ] `/lab-up` re-run on ext3 stack — confirms full Phase D.2 success